### PR TITLE
Comment out tests for alert duration feature; temporarily

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -63,14 +63,16 @@ def test_prepare_broadcast_with_new_content(driver):
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()
-
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview this alert"
+    )  # Remove once alert duration added back in
     # here check if selected areas displayed
     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-    prepare_alert_pages.click_element_by_link_text("Continue")
-    prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview this alert"
     prepare_alert_pages.click_continue()  # click "Submit for approval"
     assert prepare_alert_pages.is_text_present_on_page(
         f"{broadcast_title} is waiting for approval"
@@ -157,14 +159,16 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()
-
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview this alert"
+    )  # Remove once alert duration added back in
     # here check if selected areas displayed
     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-    prepare_alert_pages.click_element_by_link_text("Continue")
-    prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    prepare_alert_pages.click_continue()  # click "Preview this alert"
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview this alert"
     prepare_alert_pages.click_continue()  # click "Submit for approval"
     assert prepare_alert_pages.is_text_present_on_page(
         f"{template_name} is waiting for approval"


### PR DESCRIPTION
Temporary comment out of alert duration feature tests, prior to decoupling cutover.