### PR TITLE
adding empty screenshot directory

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -27,6 +27,9 @@ phases:
       - python3.9 -m pip install --upgrade pip wheel setuptools
       - make bootstrap
       - make test
+  post_build:
+    commands:
+      - mkdir screenshots
 
 artifacts:
   files:


### PR DESCRIPTION
Adding an empty screenshot directory to the pipeline run so that the functional test pipeline no longer fails in AWS