### PR TITLE
EAS-1515 Fix Functional Test Timeout Errors

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,4 +1,4 @@
-# import time
+import time
 import uuid
 
 import pytest
@@ -160,7 +160,7 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    # time.sleep(5)
+    time.sleep(5)
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 
 import pytest
@@ -159,6 +160,7 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
+    time.sleep(5)
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,28 +1,28 @@
 import uuid
-from datetime import datetime, timedelta
 
 import pytest
 
-from config import config
-from tests.functional.preview_and_dev.sample_cap_xml import (
-    ALERT_XML,
-    CANCEL_XML,
-)
-from tests.pages import (
+# from tests.functional.preview_and_dev.sample_cap_xml import (
+#     ALERT_XML,
+#     CANCEL_XML,
+# )
+from tests.pages import (  # ShowTemplatesPage,
     BasePage,
     BroadcastFreeformPage,
     DashboardPage,
-    ShowTemplatesPage,
 )
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
     check_alert_is_published_on_govuk_alerts,
-    convert_naive_utc_datetime_to_cap_standard_string,
-    create_broadcast_template,
-    delete_template,
-    go_to_templates_page,
     recordtime,
 )
+
+# convert_naive_utc_datetime_to_cap_standard_string, create_broadcast_template, delete_template, go_to_templates_page,
+
+# from config import config
+
+
+# from datetime import datetime, timedelta
 
 
 @recordtime
@@ -124,158 +124,158 @@ def test_prepare_broadcast_with_new_content(driver):
     current_alerts_page.sign_out()
 
 
-@recordtime
-@pytest.mark.xdist_group(name="broadcasts")
-def test_prepare_broadcast_with_template(driver):
-    sign_in(driver, account_type="broadcast_create_user")
+# @recordtime
+# @pytest.mark.xdist_group(name="broadcasts")
+# def test_prepare_broadcast_with_template(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
 
-    go_to_templates_page(driver, service="broadcast_service")
-    template_name = "test broadcast" + str(uuid.uuid4())
-    content = "This is a test only."
-    create_broadcast_template(driver, name=template_name, content=content)
+#     go_to_templates_page(driver, service="broadcast_service")
+#     template_name = "test broadcast" + str(uuid.uuid4())
+#     content = "This is a test only."
+#     create_broadcast_template(driver, name=template_name, content=content)
 
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service(
-        service_id=config["broadcast_service"]["id"]
-    )
+#     dashboard_page = DashboardPage(driver)
+#     dashboard_page.go_to_dashboard_for_service(
+#         service_id=config["broadcast_service"]["id"]
+#     )
 
-    dashboard_page.click_element_by_link_text("Current alerts")
+#     dashboard_page.click_element_by_link_text("Current alerts")
 
-    current_alerts_page = BasePage(driver)
-    current_alerts_page.click_element_by_link_text("New alert")
+#     current_alerts_page = BasePage(driver)
+#     current_alerts_page.click_element_by_link_text("New alert")
 
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="template")
-    new_alert_page.click_continue()
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="template")
+#     new_alert_page.click_continue()
 
-    templates_page = ShowTemplatesPage(driver)
-    templates_page.click_template_by_link_text(template_name)
+#     templates_page = ShowTemplatesPage(driver)
+#     templates_page.click_template_by_link_text(template_name)
 
-    templates_page.click_element_by_link_text("Get ready to send")
+#     templates_page.click_element_by_link_text("Get ready to send")
 
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text(
-        "Preview this alert"
-    )  # Remove once alert duration added back in
-    # here check if selected areas displayed
-    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
-    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text(
+#         "Preview this alert"
+#     )  # Remove once alert duration added back in
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+#     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-    # prepare_alert_pages.click_element_by_link_text("Continue")
-    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    # prepare_alert_pages.click_continue()  # click "Preview this alert"
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.is_text_present_on_page(
-        f"{template_name} is waiting for approval"
-    )
+#     # prepare_alert_pages.click_element_by_link_text("Continue")
+#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+#     # prepare_alert_pages.click_continue()  # click "Preview this alert"
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.is_text_present_on_page(
+#         f"{template_name} is waiting for approval"
+#     )
 
-    prepare_alert_pages.click_element_by_link_text("Discard this alert")
-    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.is_text_present_on_page(template_name)
+#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
+#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.is_text_present_on_page(template_name)
 
-    delete_template(driver, template_name, service="broadcast_service")
+#     delete_template(driver, template_name, service="broadcast_service")
 
-    prepare_alert_pages.sign_out()
-
-
-@recordtime
-@pytest.mark.xdist_group(name="broadcasts")
-def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
-
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
-
-    sign_in(driver, account_type="broadcast_approve_user")
-    page = BasePage(driver)
-    page.click_element_by_link_text("Current alerts")
-    page.click_element_by_link_text(event)
-
-    assert page.is_text_present_on_page(f"An API call wants to broadcast {event}")
-
-    reject_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(reject_broadcast_xml)
-
-    page.click_element_by_link_text("Rejected alerts")
-    assert page.is_text_present_on_page(event)
-
-    page.sign_out()
+#     prepare_alert_pages.sign_out()
 
 
-@recordtime
-@pytest.mark.xdist_group(name="broadcasts")
-def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
+# @recordtime
+# @pytest.mark.xdist_group(name="broadcasts")
+# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.utcnow() - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
 
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
 
-    sign_in(driver, account_type="broadcast_approve_user")
+#     sign_in(driver, account_type="broadcast_approve_user")
+#     page = BasePage(driver)
+#     page.click_element_by_link_text("Current alerts")
+#     page.click_element_by_link_text(event)
 
-    page = BasePage(driver)
-    page.click_element_by_link_text("Current alerts")
-    page.click_element_by_link_text(event)
-    page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    page.click_continue()
+#     assert page.is_text_present_on_page(f"An API call wants to broadcast {event}")
 
-    assert page.is_text_present_on_page("since today at")
+#     reject_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
 
-    alert_page_url = page.current_url
+#     page.click_element_by_link_text("Rejected alerts")
+#     assert page.is_text_present_on_page(event)
 
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     page.sign_out()
 
-    cancel_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-    # go back to the page for the current alert
-    page.get(alert_page_url)
+# @recordtime
+# @pytest.mark.xdist_group(name="broadcasts")
+# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.utcnow() - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
 
-    # assert that it's now cancelled
-    assert page.is_text_present_on_page("Stopped by an API call")
-    page.click_element_by_link_text("Past alerts")
-    assert page.is_text_present_on_page(event)
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
 
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    page.get()
-    page.sign_out()
+#     page = BasePage(driver)
+#     page.click_element_by_link_text("Current alerts")
+#     page.click_element_by_link_text(event)
+#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     page.click_continue()
+
+#     assert page.is_text_present_on_page("since today at")
+
+#     alert_page_url = page.current_url
+
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     cancel_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+#     # go back to the page for the current alert
+#     page.get(alert_page_url)
+
+#     # assert that it's now cancelled
+#     assert page.is_text_present_on_page("Stopped by an API call")
+#     page.click_element_by_link_text("Past alerts")
+#     assert page.is_text_present_on_page(event)
+
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     page.get()
+#     page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,13 +1,13 @@
 import uuid
+from datetime import datetime, timedelta
 
 import pytest
 
 from config import config
-
-# from tests.functional.preview_and_dev.sample_cap_xml import (
-#     ALERT_XML,
-#     CANCEL_XML,
-# )
+from tests.functional.preview_and_dev.sample_cap_xml import (
+    ALERT_XML,
+    CANCEL_XML,
+)
 from tests.pages import (
     BasePage,
     BroadcastFreeformPage,
@@ -17,16 +17,12 @@ from tests.pages import (
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
     check_alert_is_published_on_govuk_alerts,
+    convert_naive_utc_datetime_to_cap_standard_string,
     create_broadcast_template,
     delete_template,
     go_to_templates_page,
     recordtime,
 )
-
-# convert_naive_utc_datetime_to_cap_standard_string,
-
-
-# from datetime import datetime, timedelta
 
 
 @recordtime
@@ -189,98 +185,98 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages.sign_out()
 
 
-# @recordtime
-# @pytest.mark.xdist_group(name="broadcasts")
-# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.utcnow() - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
+@recordtime
+@pytest.mark.xdist_group(name="broadcasts")
+def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.utcnow() - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
 
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
 
-#     sign_in(driver, account_type="broadcast_approve_user")
-#     page = BasePage(driver)
-#     page.click_element_by_link_text("Current alerts")
-#     page.click_element_by_link_text(event)
+    sign_in(driver, account_type="broadcast_approve_user")
+    page = BasePage(driver)
+    page.click_element_by_link_text("Current alerts")
+    page.click_element_by_link_text(event)
 
-#     assert page.is_text_present_on_page(f"An API call wants to broadcast {event}")
+    assert page.is_text_present_on_page(f"An API call wants to broadcast {event}")
 
-#     reject_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
+    reject_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(reject_broadcast_xml)
 
-#     page.click_element_by_link_text("Rejected alerts")
-#     assert page.is_text_present_on_page(event)
+    page.click_element_by_link_text("Rejected alerts")
+    assert page.is_text_present_on_page(event)
 
-#     page.sign_out()
+    page.sign_out()
 
 
-# @recordtime
-# @pytest.mark.xdist_group(name="broadcasts")
-# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.utcnow() - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
+@recordtime
+@pytest.mark.xdist_group(name="broadcasts")
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.utcnow() - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
 
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
 
-#     sign_in(driver, account_type="broadcast_approve_user")
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     page = BasePage(driver)
-#     page.click_element_by_link_text("Current alerts")
-#     page.click_element_by_link_text(event)
-#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     page.click_continue()
+    page = BasePage(driver)
+    page.click_element_by_link_text("Current alerts")
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_continue()
 
-#     assert page.is_text_present_on_page("since today at")
+    assert page.is_text_present_on_page("since today at")
 
-#     alert_page_url = page.current_url
+    alert_page_url = page.current_url
 
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
 
-#     cancel_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-#     # go back to the page for the current alert
-#     page.get(alert_page_url)
+    # go back to the page for the current alert
+    page.get(alert_page_url)
 
-#     # assert that it's now cancelled
-#     assert page.is_text_present_on_page("Stopped by an API call")
-#     page.click_element_by_link_text("Past alerts")
-#     assert page.is_text_present_on_page(event)
+    # assert that it's now cancelled
+    assert page.is_text_present_on_page("Stopped by an API call")
+    page.click_element_by_link_text("Past alerts")
+    assert page.is_text_present_on_page(event)
 
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-#     page.get()
-#     page.sign_out()
+    page.get()
+    page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -2,24 +2,28 @@ import uuid
 
 import pytest
 
+from config import config
+
 # from tests.functional.preview_and_dev.sample_cap_xml import (
 #     ALERT_XML,
 #     CANCEL_XML,
 # )
-from tests.pages import (  # ShowTemplatesPage,
+from tests.pages import (
     BasePage,
     BroadcastFreeformPage,
     DashboardPage,
+    ShowTemplatesPage,
 )
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
     check_alert_is_published_on_govuk_alerts,
+    create_broadcast_template,
+    delete_template,
+    go_to_templates_page,
     recordtime,
 )
 
-# convert_naive_utc_datetime_to_cap_standard_string, create_broadcast_template, delete_template, go_to_templates_page,
-
-# from config import config
+# convert_naive_utc_datetime_to_cap_standard_string,
 
 
 # from datetime import datetime, timedelta
@@ -63,6 +67,7 @@ def test_prepare_broadcast_with_new_content(driver):
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()
+
     prepare_alert_pages.click_element_by_link_text(
         "Preview this alert"
     )  # Remove once alert duration added back in
@@ -124,64 +129,64 @@ def test_prepare_broadcast_with_new_content(driver):
     current_alerts_page.sign_out()
 
 
-# @recordtime
-# @pytest.mark.xdist_group(name="broadcasts")
-# def test_prepare_broadcast_with_template(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
+@recordtime
+@pytest.mark.xdist_group(name="broadcasts")
+def test_prepare_broadcast_with_template(driver):
+    sign_in(driver, account_type="broadcast_create_user")
 
-#     go_to_templates_page(driver, service="broadcast_service")
-#     template_name = "test broadcast" + str(uuid.uuid4())
-#     content = "This is a test only."
-#     create_broadcast_template(driver, name=template_name, content=content)
+    go_to_templates_page(driver, service="broadcast_service")
+    template_name = "test broadcast" + str(uuid.uuid4())
+    content = "This is a test only."
+    create_broadcast_template(driver, name=template_name, content=content)
 
-#     dashboard_page = DashboardPage(driver)
-#     dashboard_page.go_to_dashboard_for_service(
-#         service_id=config["broadcast_service"]["id"]
-#     )
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(
+        service_id=config["broadcast_service"]["id"]
+    )
 
-#     dashboard_page.click_element_by_link_text("Current alerts")
+    dashboard_page.click_element_by_link_text("Current alerts")
 
-#     current_alerts_page = BasePage(driver)
-#     current_alerts_page.click_element_by_link_text("New alert")
+    current_alerts_page = BasePage(driver)
+    current_alerts_page.click_element_by_link_text("New alert")
 
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="template")
-#     new_alert_page.click_continue()
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="template")
+    new_alert_page.click_continue()
 
-#     templates_page = ShowTemplatesPage(driver)
-#     templates_page.click_template_by_link_text(template_name)
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
 
-#     templates_page.click_element_by_link_text("Get ready to send")
+    templates_page.click_element_by_link_text("Get ready to send")
 
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text(
-#         "Preview this alert"
-#     )  # Remove once alert duration added back in
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
-#     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview this alert"
+    )  # Remove once alert duration added back in
+    # here check if selected areas displayed
+    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-#     # prepare_alert_pages.click_element_by_link_text("Continue")
-#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-#     # prepare_alert_pages.click_continue()  # click "Preview this alert"
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.is_text_present_on_page(
-#         f"{template_name} is waiting for approval"
-#     )
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview this alert"
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.is_text_present_on_page(
+        f"{template_name} is waiting for approval"
+    )
 
-#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
-#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.is_text_present_on_page(template_name)
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.is_text_present_on_page(template_name)
 
-#     delete_template(driver, template_name, service="broadcast_service")
+    delete_template(driver, template_name, service="broadcast_service")
 
-#     prepare_alert_pages.sign_out()
+    prepare_alert_pages.sign_out()
 
 
 # @recordtime

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,4 +1,4 @@
-import time
+# import time
 import uuid
 
 import pytest
@@ -160,7 +160,7 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    time.sleep(5)
+    # time.sleep(5)
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -8,13 +8,15 @@ from config import config
 #     ALERT_XML,
 #     CANCEL_XML,
 # )
-from tests.pages import (  # BroadcastFreeformPage,
+from tests.pages import (
     BasePage,
+    BroadcastFreeformPage,
     DashboardPage,
     ShowTemplatesPage,
 )
 from tests.pages.rollups import sign_in
-from tests.test_utils import (  # check_alert_is_published_on_govuk_alerts,
+from tests.test_utils import (
+    check_alert_is_published_on_govuk_alerts,
     create_broadcast_template,
     delete_template,
     go_to_templates_page,
@@ -27,104 +29,104 @@ from tests.test_utils import (  # check_alert_is_published_on_govuk_alerts,
 # from datetime import datetime, timedelta
 
 
-# @recordtime
-# @pytest.mark.xdist_group(name="broadcasts")
-# def test_prepare_broadcast_with_new_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
+@recordtime
+@pytest.mark.xdist_group(name="broadcasts")
+def test_prepare_broadcast_with_new_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
 
-#     landing_page = BasePage(driver)
-#     if not landing_page.is_text_present_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             "Functional Tests Broadcast Service"
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
+    landing_page = BasePage(driver)
+    if not landing_page.is_text_present_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            "Functional Tests Broadcast Service"
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
 
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
 
-#     current_alerts_page.click_element_by_link_text("New alert")
+    current_alerts_page.click_element_by_link_text("New alert")
 
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
 
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
 
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
-#     prepare_alert_pages.click_continue()
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
+    prepare_alert_pages.click_continue()
 
-#     prepare_alert_pages.click_element_by_link_text(
-#         "Preview this alert"
-#     )  # Remove once alert duration added back in
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
-#     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview this alert"
+    )  # Remove once alert duration added back in
+    # here check if selected areas displayed
+    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-#     # prepare_alert_pages.click_element_by_link_text("Continue")
-#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-#     # prepare_alert_pages.click_continue()  # click "Preview this alert"
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.is_text_present_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview this alert"
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.is_text_present_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
 
-#     prepare_alert_pages.sign_out()
+    prepare_alert_pages.sign_out()
 
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     landing_page = BasePage(driver)
-#     if not landing_page.is_text_present_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             "Functional Tests Broadcast Service"
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
+    landing_page = BasePage(driver)
+    if not landing_page.is_text_present_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            "Functional Tests Broadcast Service"
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
 
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.is_text_present_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.is_text_present_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
 
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
 
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
 
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.is_text_present_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.is_text_present_on_page(broadcast_title)
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.is_text_present_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.is_text_present_on_page(broadcast_title)
 
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-#     # sign out
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+    # sign out
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
 
 
 @recordtime

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 
 import pytest
@@ -160,7 +159,6 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    time.sleep(5)
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
     prepare_alert_pages.click_continue()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -8,15 +8,13 @@ from config import config
 #     ALERT_XML,
 #     CANCEL_XML,
 # )
-from tests.pages import (
+from tests.pages import (  # BroadcastFreeformPage,
     BasePage,
-    BroadcastFreeformPage,
     DashboardPage,
     ShowTemplatesPage,
 )
 from tests.pages.rollups import sign_in
-from tests.test_utils import (
-    check_alert_is_published_on_govuk_alerts,
+from tests.test_utils import (  # check_alert_is_published_on_govuk_alerts,
     create_broadcast_template,
     delete_template,
     go_to_templates_page,
@@ -29,104 +27,104 @@ from tests.test_utils import (
 # from datetime import datetime, timedelta
 
 
-@recordtime
-@pytest.mark.xdist_group(name="broadcasts")
-def test_prepare_broadcast_with_new_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
+# @recordtime
+# @pytest.mark.xdist_group(name="broadcasts")
+# def test_prepare_broadcast_with_new_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
 
-    landing_page = BasePage(driver)
-    if not landing_page.is_text_present_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            "Functional Tests Broadcast Service"
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
+#     landing_page = BasePage(driver)
+#     if not landing_page.is_text_present_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             "Functional Tests Broadcast Service"
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
 
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
 
-    current_alerts_page.click_element_by_link_text("New alert")
+#     current_alerts_page.click_element_by_link_text("New alert")
 
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
 
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
 
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
-    prepare_alert_pages.click_continue()
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd21-E05007565")
+#     prepare_alert_pages.click_continue()
 
-    prepare_alert_pages.click_element_by_link_text(
-        "Preview this alert"
-    )  # Remove once alert duration added back in
-    # here check if selected areas displayed
-    assert prepare_alert_pages.is_text_present_on_page("Cokeham")
-    assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
+#     prepare_alert_pages.click_element_by_link_text(
+#         "Preview this alert"
+#     )  # Remove once alert duration added back in
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.is_text_present_on_page("Cokeham")
+#     assert prepare_alert_pages.is_text_present_on_page("Eastbrook")
 
-    # prepare_alert_pages.click_element_by_link_text("Continue")
-    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    # prepare_alert_pages.click_continue()  # click "Preview this alert"
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.is_text_present_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
+#     # prepare_alert_pages.click_element_by_link_text("Continue")
+#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+#     # prepare_alert_pages.click_continue()  # click "Preview this alert"
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.is_text_present_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
 
-    prepare_alert_pages.sign_out()
+#     prepare_alert_pages.sign_out()
 
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    landing_page = BasePage(driver)
-    if not landing_page.is_text_present_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            "Functional Tests Broadcast Service"
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
+#     landing_page = BasePage(driver)
+#     if not landing_page.is_text_present_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             "Functional Tests Broadcast Service"
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
 
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.is_text_present_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.is_text_present_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
 
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
 
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
 
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.is_text_present_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.is_text_present_on_page(broadcast_title)
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.is_text_present_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.is_text_present_on_page(broadcast_title)
 
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-    # sign out
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+#     # sign out
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
 
 
 @recordtime

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -88,14 +88,14 @@ class AntiStaleElement(AntiStale):
                 self.element,
             )
             try:
-                time.sleep(5)
+                time.sleep(2)
                 self.element.click()
             except WebDriverException:
                 self.driver.execute_script(
                     "arguments[0].scrollIntoView({ behavior: 'instant', block: 'start', inline: 'nearest' })",
                     self.element,
                 )
-                time.sleep(5)
+                # time.sleep(5)
                 self.element.click()
 
         return self.retry_on_stale(_click)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -95,7 +95,6 @@ class AntiStaleElement(AntiStale):
                     "arguments[0].scrollIntoView({ behavior: 'instant', block: 'start', inline: 'nearest' })",
                     self.element,
                 )
-                # time.sleep(5)
                 self.element.click()
 
         return self.retry_on_stale(_click)
@@ -179,7 +178,7 @@ class BasePage(object):
 
         return check_contains_url
 
-    def select_checkbox_or_radio(self, element=None, value=None, text=None):
+    def select_checkbox_or_radio(self, element=None, value=None):
         if not element and value:
             locator = (By.CSS_SELECTOR, f"[value={value}]")
             element = self.wait_for_invisible_element(locator)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -176,7 +176,7 @@ class BasePage(object):
 
         return check_contains_url
 
-    def select_checkbox_or_radio(self, element=None, value=None):
+    def select_checkbox_or_radio(self, element=None, value=None, text=None):
         if not element and value:
             locator = (By.CSS_SELECTOR, f"[value={value}]")
             element = self.wait_for_invisible_element(locator)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 
 from retry import retry
 from selenium.common.exceptions import (
@@ -87,12 +88,14 @@ class AntiStaleElement(AntiStale):
                 self.element,
             )
             try:
+                time.sleep(5)
                 self.element.click()
             except WebDriverException:
                 self.driver.execute_script(
                     "arguments[0].scrollIntoView({ behavior: 'instant', block: 'start', inline: 'nearest' })",
                     self.element,
                 )
+                time.sleep(5)
                 self.element.click()
 
         return self.retry_on_stale(_click)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -83,13 +83,15 @@ class AntiStaleElement(AntiStale):
             # an element might be hidden underneath other elements (eg sticky nav items). To counter this, we can use
             # the scrollIntoView function to bring it to the top of the page
             self.driver.execute_script(
-                "arguments[0].scrollIntoViewIfNeeded()", self.element
+                "arguments[0].scrollIntoView({ behavior: 'instant', block: 'start', inline: 'nearest' })",
+                self.element,
             )
             try:
                 self.element.click()
             except WebDriverException:
                 self.driver.execute_script(
-                    "arguments[0].scrollIntoView()", self.element
+                    "arguments[0].scrollIntoView({ behavior: 'instant', block: 'start', inline: 'nearest' })",
+                    self.element,
                 )
                 self.element.click()
 
@@ -555,6 +557,8 @@ class EditSmsTemplatePage(BasePage):
     name_input = NameInputElement()
     template_content_input = TemplateContentElement()
     save_button = EditTemplatePageLocators.SAVE_BUTTON
+    delete_button = EditTemplatePageLocators.DELETE_BUTTON
+    confirm_delete_button = EditTemplatePageLocators.CONFIRM_DELETE_BUTTON
 
     def click_save(self):
         element = self.wait_for_element(EditSmsTemplatePage.save_button)
@@ -567,6 +571,12 @@ class EditSmsTemplatePage(BasePage):
         else:
             self.template_content_input = "The quick brown fox jumped over the lazy dog. Jenkins job id: ((build_id))"
         self.click_save()
+
+    def click_delete(self):
+        element = self.wait_for_element(EditSmsTemplatePage.delete_button)
+        element.click()
+        element = self.wait_for_element(EditSmsTemplatePage.confirm_delete_button)
+        element.click()
 
 
 class EditBroadcastTemplatePage(EditSmsTemplatePage):

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -4,12 +4,18 @@ from tests.test_utils import do_email_auth_verify, do_verify, do_verify_by_id
 
 
 def sign_in(driver, account_type="normal"):
+    clean_session(driver)
+
     _sign_in(driver, account_type)
     identifier = get_identifier(account_type=account_type)
     if account_type.startswith("broadcast"):
         do_verify_by_id(driver, identifier)
     else:
         do_verify(driver, identifier)
+
+
+def clean_session(driver):
+    driver.delete_all_cookies()
 
 
 def sign_in_email_auth(driver):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,7 +313,7 @@ def delete_template(driver, template_name, service="service"):
         dashboard_page.go_to_dashboard_for_service(config[service]["id"])
         dashboard_page.click_templates()
         show_templates_page.click_template_by_link_text(template_name)
-    template_page = EditEmailTemplatePage(driver)
+    template_page = EditSmsTemplatePage(driver)
     template_page.click_delete()
 
 


### PR DESCRIPTION
The following changes have been made to reduce errors in the functional tests:
- Correctly apply the Sms page template to reduce timeouts waiting for missing page elements
- Add a session-clearing step to reduce chains of test failures due to existing sessions on sign-in
- Add a small delay inside the AntiStaleElement retry loop to allow page rendering to complete before click() is applied