### PR TITLE
EAS-1808 Apply temporary sleeps to ensure website has time to render

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from datetime import datetime, timedelta
 
@@ -111,6 +112,7 @@ def test_prepare_broadcast_with_new_content(driver):
     # stop sending the alert
     current_alerts_page.click_element_by_link_text("Stop sending")
     current_alerts_page.click_continue()  # stop broadcasting
+    time.sleep(10)
     assert current_alerts_page.is_text_present_on_page(
         "Stopped by Functional Tests - Broadcast User Approve"
     )

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -102,6 +102,7 @@ def test_prepare_broadcast_with_new_content(driver):
     assert current_alerts_page.is_text_present_on_page("since today at")
     alert_page_url = current_alerts_page.current_url
 
+    time.sleep(180)
     check_alert_is_published_on_govuk_alerts(
         driver, "Current alerts", broadcast_content
     )
@@ -112,7 +113,6 @@ def test_prepare_broadcast_with_new_content(driver):
     # stop sending the alert
     current_alerts_page.click_element_by_link_text("Stop sending")
     current_alerts_page.click_continue()  # stop broadcasting
-    time.sleep(10)
     assert current_alerts_page.is_text_present_on_page(
         "Stopped by Functional Tests - Broadcast User Approve"
     )
@@ -120,6 +120,7 @@ def test_prepare_broadcast_with_new_content(driver):
     past_alerts_page = BasePage(driver)
     assert past_alerts_page.is_text_present_on_page(broadcast_title)
 
+    time.sleep(180)
     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
     # sign out
@@ -258,6 +259,7 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
 
     alert_page_url = page.current_url
 
+    time.sleep(180)
     check_alert_is_published_on_govuk_alerts(
         driver, "Current alerts", broadcast_content
     )
@@ -278,6 +280,7 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     page.click_element_by_link_text("Past alerts")
     assert page.is_text_present_on_page(event)
 
+    time.sleep(180)
     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
     page.get()


### PR DESCRIPTION
The sleeps inserted before checking the website rendering are a temporary fix to get the functional tests passing. The clean-up of old test alerts will allow these wait periods to be removed in an upcoming unit of work.