### PR TITLE
EAS-2021 Fix login flow to account for multiple services

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,7 @@ env:
   variables:
     testsuites: >-
       platform-admin-flow
+      template-flow
 
 # broadcast-flow
 # cbc-integration
@@ -59,7 +60,7 @@ phases:
       # - make test-authentication-flow; exit 0
       # - make test-top-rail-services; exit 0
       # - make test-links-and-cookies; exit 0
-      # - make test-template-flow; exit 0
+      - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,7 +4,6 @@ env:
   variables:
     testsuites: >-
       platform-admin-flow
-      template-flow
 
 # broadcast-flow
 # cbc-integration
@@ -58,9 +57,8 @@ phases:
       # - make test-cbc-integration; exit 0
       - make test-platform-admin-flow; exit 0
       # - make test-authentication-flow; exit 0
-      # - make test-top-rail-services; exit 0
       # - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
+      # - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -3,12 +3,14 @@ version: 0.2
 env:
   variables:
     testsuites: >-
-      broadcast-flow
-      cbc-integration
       platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
+
+# broadcast-flow
+# cbc-integration
+# platform-admin-flow
+# authentication-flow
+# links-and-cookies
+# template-flow
 
 phases:
   install:
@@ -51,13 +53,13 @@ phases:
   build:
     on-failure: CONTINUE
     commands:
-      - make test-broadcast-flow; exit 0
-      - make test-cbc-integration; exit 0
+      # - make test-broadcast-flow; exit 0
+      # - make test-cbc-integration; exit 0
       - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
+      # - make test-authentication-flow; exit 0
       # - make test-top-rail-services; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
+      # - make test-links-and-cookies; exit 0
+      # - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -3,14 +3,12 @@ version: 0.2
 env:
   variables:
     testsuites: >-
+      broadcast-flow
+      cbc-integration
       platform-admin-flow
-
-# broadcast-flow
-# cbc-integration
-# platform-admin-flow
-# authentication-flow
-# links-and-cookies
-# template-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
 
 phases:
   install:
@@ -53,12 +51,12 @@ phases:
   build:
     on-failure: CONTINUE
     commands:
-      # - make test-broadcast-flow; exit 0
-      # - make test-cbc-integration; exit 0
+      - make test-broadcast-flow; exit 0
+      - make test-cbc-integration; exit 0
       - make test-platform-admin-flow; exit 0
-      # - make test-authentication-flow; exit 0
-      # - make test-links-and-cookies; exit 0
-      # - make test-template-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -1,4 +1,4 @@
-import uuid
+import time
 
 import pytest
 
@@ -12,8 +12,8 @@ TESTSUITE_CODE = "PLATFORM-ADMIN"
 
 @pytest.mark.xdist_group(name=TESTSUITE_CODE)
 def test_add_new_service_platform_admin(driver):
-    temp_service_uuid = str(uuid.uuid4())
-    service_name = f"Functional Test_{temp_service_uuid}"
+    timestamp = str(int(time.time()))
+    service_name = f"Functional Test {timestamp}"
 
     sign_in(driver, account_type="platform_admin")
 
@@ -36,6 +36,7 @@ def test_add_new_service_platform_admin(driver):
     dashboard_page.click_element_by_link_text("Settings")
 
     service_settings_page = ServiceSettingsPage(driver)
+
     service_settings_page.click_element_by_link_text("Delete this service")
     delete_button = service_settings_page.wait_for_element(
         ServiceSettingsLocators.DELETE_CONFIRM_BUTTON

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -11,7 +11,7 @@ TESTSUITE_CODE = "PLATFORM-ADMIN"
 
 
 @pytest.mark.xdist_group(name=TESTSUITE_CODE)
-def test_add_new_service_platform_admin(driver):
+def test_add_rename_and_delete_service(driver):
     timestamp = str(int(time.time()))
     service_name = f"Functional Test {timestamp}"
 
@@ -36,7 +36,7 @@ def test_add_new_service_platform_admin(driver):
     # test service name change
     dashboard_page.click_element_by_link_text("Settings")
     service_settings_page = ServiceSettingsPage(driver)
-    service_settings_page.click_element_by_link_text("Change service name")
+    service_settings_page.click_change_setting("service name")
 
     new_service_name = service_name + " NEW"
     service_settings_page.save_service_name(new_service_name)

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -39,9 +39,6 @@ def test_add_rename_and_delete_service(driver):
     service_settings_page.click_change_setting("service name")
 
     new_service_name = service_name + " NEW"
-    print("------------------------------------------------------------")
-    print(new_service_name)
-    print("------------------------------------------------------------")
     service_settings_page.save_service_name(new_service_name)
     assert service_settings_page.check_service_name(new_service_name)
 

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -33,10 +33,16 @@ def test_add_new_service_platform_admin(driver):
 
     assert dashboard_page.get_service_name() == f"{service_name} TRAINING"
 
+    # test service name change
     dashboard_page.click_element_by_link_text("Settings")
-
     service_settings_page = ServiceSettingsPage(driver)
+    service_settings_page.click_element_by_link_text("Change service name")
 
+    new_service_name = service_name + " NEW"
+    service_settings_page.save_service_name(new_service_name)
+    assert service_settings_page.check_service_name(new_service_name)
+
+    # delete the service
     service_settings_page.click_element_by_link_text("Delete this service")
     delete_button = service_settings_page.wait_for_element(
         ServiceSettingsLocators.DELETE_CONFIRM_BUTTON

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -50,7 +50,7 @@ def test_add_rename_and_delete_service(driver):
     delete_button.click()
 
     assert service_settings_page.is_text_present_on_page(
-        f"‘{service_name}’ was deleted"
+        f"‘{new_service_name}’ was deleted"
     )
 
     # sign out

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -39,6 +39,9 @@ def test_add_rename_and_delete_service(driver):
     service_settings_page.click_change_setting("service name")
 
     new_service_name = service_name + " NEW"
+    print("------------------------------------------------------------")
+    print(new_service_name)
+    print("------------------------------------------------------------")
     service_settings_page.save_service_name(new_service_name)
     assert service_settings_page.check_service_name(new_service_name)
 

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -40,7 +40,7 @@ def test_add_rename_and_delete_service(driver):
 
     new_service_name = service_name + " NEW"
     service_settings_page.save_service_name(new_service_name)
-    assert service_settings_page.check_service_name(new_service_name)
+    assert service_settings_page.check_service_name(f"{new_service_name} TRAINING")
 
     # delete the service
     service_settings_page.click_element_by_link_text("Delete this service")

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 from tests.pages.locators import (
@@ -34,6 +35,17 @@ class BasePageElement(object):
         return element.get_attribute("value")
 
 
+class ClearableInputElement(BasePageElement):
+    def __set__(self, obj, value, clear=True):
+        driver = obj.driver
+        WebDriverWait(driver, 100).until(
+            lambda driver: driver.find_element(By.NAME, self.name)
+        )
+        input = driver.find_element(By.NAME, self.name)
+        input.send_keys(Keys.chord(Keys.CONTROL, "a"))
+        input.send_keys(value)
+
+
 class ServiceInputElement(BasePageElement):
     name = AddServicePageLocators.SERVICE_INPUT[1]
 
@@ -58,7 +70,7 @@ class SmsInputElement(BasePageElement):
     name = VerifyPageLocators.SMS_INPUT[1]
 
 
-class NameInputElement(BasePageElement):
+class NameInputElement(ClearableInputElement):
     name = CommonPageLocators.NAME_INPUT[1]
 
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -44,7 +44,7 @@ class ClearableInputElement(BasePageElement):
             lambda driver: driver.find_element(By.NAME, self.name)
         )
         input = driver.find_element(By.NAME, self.name)
-        input.send_keys(Keys.chord(Keys.CONTROL, "a"))
+        input.send_keys(Keys.CONTROL + "a")
         input.send_keys(value)
 
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -36,6 +36,8 @@ class BasePageElement(object):
 
 
 class ClearableInputElement(BasePageElement):
+    name = CommonPageLocators.NAME_INPUT[1]
+
     def __set__(self, obj, value, clear=True):
         driver = obj.driver
         WebDriverWait(driver, 100).until(

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -965,6 +965,7 @@ class ServiceSettingsPage(BasePage):
 
     def save_service_name(self, new_name):
         self.name_input = new_name
+        raise ValueError("Fail here")
         self.click_save()
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -959,8 +959,6 @@ class ServiceSettingsPage(BasePage):
 
     def check_service_name(self, expected_name):
         name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
-        print(expected_name)
-        print(name.element.text)
         if name.element.text == expected_name:
             return True
         else:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -945,6 +945,17 @@ class SendOneRecipient(BasePage):
 class ServiceSettingsPage(BasePage):
     name_input = NameInputElement()
 
+    @staticmethod
+    def change_setting_link(text, setting):
+        return (
+            By.XPATH,
+            f"//a[contains(normalize-space(.),'Change')]/span[contains(normalize-space(.),'{setting}')]/parent::a",
+        )
+
+    def click_change_setting(self, setting):
+        element = self.wait_for_element(self.change_setting_link(setting))
+        element.click()
+
     def check_service_name(self, expected_name):
         name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
         if name.element.text == expected_name:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -943,12 +943,18 @@ class SendOneRecipient(BasePage):
 
 
 class ServiceSettingsPage(BasePage):
+    name_input = NameInputElement()
+
     def check_service_name(self, expected_name):
         name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
         if name.element.text == expected_name:
             return True
         else:
             raise ValueError("Service name not changed succesfully")
+
+    def save_service_name(self, new_name):
+        self.name_input = new_name
+        self.click_save()
 
 
 class ChangeName(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -959,6 +959,8 @@ class ServiceSettingsPage(BasePage):
 
     def check_service_name(self, expected_name):
         name = self.wait_for_element(ServiceSettingsLocators.SERVICE_NAME)
+        print(expected_name)
+        print(name.element.text)
         if name.element.text == expected_name:
             return True
         else:

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -946,7 +946,7 @@ class ServiceSettingsPage(BasePage):
     name_input = NameInputElement()
 
     @staticmethod
-    def change_setting_link(text, setting):
+    def change_setting_link(setting):
         return (
             By.XPATH,
             f"//a[contains(normalize-space(.),'Change')]/span[contains(normalize-space(.),'{setting}')]/parent::a",

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from config import config
 from tests.pages.element import (
     BasePageElement,
+    ClearableInputElement,
     EmailInputElement,
     FeedbackTextAreaElement,
     FileInputElement,
@@ -943,7 +944,7 @@ class SendOneRecipient(BasePage):
 
 
 class ServiceSettingsPage(BasePage):
-    name_input = NameInputElement()
+    name_input = ClearableInputElement()
 
     @staticmethod
     def change_setting_link(setting):
@@ -965,7 +966,6 @@ class ServiceSettingsPage(BasePage):
 
     def save_service_name(self, new_name):
         self.name_input = new_name
-        raise ValueError("Fail here")
         self.click_save()
 
 

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -11,6 +11,7 @@ from tests.test_utils import (
     do_email_auth_verify,
     do_verify,
     do_verify_by_id,
+    go_to_service_dashboard,
 )
 
 
@@ -28,12 +29,7 @@ def sign_in(driver, account_type="normal"):
     else:
         do_verify(driver, identifier)
 
-    landing_page = BasePage(driver)
-    if not landing_page.is_text_present_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        landing_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
+    go_to_service_dashboard(driver, "broadcast_service")
 
 
 def clean_session(driver):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -308,6 +308,11 @@ def create_broadcast_template(driver, name="test template", content=None):
     return template_page.get_template_id()
 
 
+def go_to_service_dashboard(driver, service="service"):
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(config[service]["id"])
+
+
 def go_to_templates_page(driver, service="service"):
     dashboard_page = DashboardPage(driver)
     dashboard_page.go_to_dashboard_for_service(config[service]["id"])


### PR DESCRIPTION
When testing service creation, the login flow lands on the service selection page if there is more than one service. The login rollup is modified to account for this behaviour.

The platform admin test is also enhanced by testing the service re-naming flow.