### PR TITLE
EAS-2012 Add calls to purge endpoints in pytest setup

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,11 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      cbc-integration
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
 
 phases:
   install:
@@ -47,11 +52,11 @@ phases:
     on-failure: CONTINUE
     commands:
       - make test-broadcast-flow; exit 0
-      # - make test-cbc-integration; exit 0
-      # - make test-platform-admin-flow; exit 0
-      # - make test-authentication-flow; exit 0
-      # - make test-links-and-cookies; exit 0
-      # - make test-template-flow; exit 0
+      - make test-cbc-integration; exit 0
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,11 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      cbc-integration
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
 
 phases:
   install:
@@ -52,11 +47,11 @@ phases:
     on-failure: CONTINUE
     commands:
       - make test-broadcast-flow; exit 0
-      - make test-cbc-integration; exit 0
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
+      # - make test-cbc-integration; exit 0
+      # - make test-platform-admin-flow; exit 0
+      # - make test-authentication-flow; exit 0
+      # - make test-links-and-cookies; exit 0
+      # - make test-template-flow; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -3,6 +3,13 @@ import pytest
 from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
 
+test_api_client = TestApiClient()
+test_api_client.configure_for_internal_client(
+    client_id=config["service"]["internal_api_client_id"],
+    api_key=config["service"]["internal_api_client_secret"],
+    base_url=config["eas_api_url"],
+)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def preview_dev_config():
@@ -12,17 +19,30 @@ def preview_dev_config():
     setup_preview_dev_config()
 
     _purge_functional_test_alerts()
+    _purge_folders_and_templates()
+    _purge_user_created_services()
 
 
 def _purge_functional_test_alerts():
-    client = TestApiClient()
-    client.configure_for_internal_client(
-        client_id=config["service"]["internal_api_client_id"],
-        api_key=config["service"]["internal_api_client_secret"],
-        base_url=config["eas_api_url"],
-    )
     service = config["broadcast_service"]["service_id"]
     older_than = config["broadcast_service"]["purge_older_than"]
-    url = f"/service/{service}/broadcast-message/purge/{older_than}"
 
-    client.get(url)
+    url = f"/service/{service}/broadcast-message/purge/{older_than}"
+    test_api_client.delete(url)
+
+
+def _purge_folders_and_templates():
+    service = config["broadcast_service"]["service_id"]
+
+    url = f"/service/{service}/template/purge"
+    test_api_client.delete(url)
+
+    url = f"/service/{service}/template-folder/purge"
+    test_api_client.delete(url)
+
+
+def _purge_user_created_services():
+    admin_user = config["broadcast_service"]["platform_admin"]["id"]
+
+    url = f"/service/purge-services-created/{admin_user}"
+    test_api_client.delete(url)

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -37,9 +37,6 @@ def _purge_folders_and_templates():
     url = f"/service/{service}/template/purge"
     test_api_client.delete(url)
 
-    url = f"/service/{service}/template-folder/purge"
-    test_api_client.delete(url)
-
 
 def _purge_user_created_services():
     admin_user = config["broadcast_service"]["platform_admin"]["id"]


### PR DESCRIPTION
The pytest setup phase should call API endpoints to purge templates & folders and any services created by the Functional Test account.