### PR TITLE
EAS-2041 Add LoopbackResponse reset and tear-down step to clear test blackout

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -3,7 +3,13 @@ version: 0.2
 env:
   variables:
     testsuites: >-
+      broadcast-flow
       cbc-integration
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
 
 phases:
   install:
@@ -46,13 +52,13 @@ phases:
   build:
     on-failure: CONTINUE
     commands:
-      # - make test-broadcast-flow; exit 0
+      - make test-broadcast-flow; exit 0
       - make test-cbc-integration; exit 0
-      # - make test-platform-admin-flow; exit 0
-      # - make test-authentication-flow; exit 0
-      # - make test-links-and-cookies; exit 0
-      # - make test-template-flow; exit 0
-      # - make test-user-operations; exit 0
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -3,13 +3,7 @@ version: 0.2
 env:
   variables:
     testsuites: >-
-      broadcast-flow
       cbc-integration
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
 
 phases:
   install:
@@ -52,13 +46,13 @@ phases:
   build:
     on-failure: CONTINUE
     commands:
-      - make test-broadcast-flow; exit 0
+      # - make test-broadcast-flow; exit 0
       - make test-cbc-integration; exit 0
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
+      # - make test-platform-admin-flow; exit 0
+      # - make test-authentication-flow; exit 0
+      # - make test-links-and-cookies; exit 0
+      # - make test-template-flow; exit 0
+      # - make test-user-operations; exit 0
       - echo "Test run completed."
       - touch "$(pwd)/test-failures"
       - chmod +rw "$(pwd)/test-failures"

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -29,7 +29,7 @@ def preview_dev_config():
     yield
 
     set_response_codes()
-    put_functional_test_blackout_metric(None, False)
+    put_functional_test_blackout_metric(200)
 
 
 def purge_functional_test_alerts(test_api_client):

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -2,6 +2,10 @@ import pytest
 
 from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
+from tests.test_utils import (
+    put_functional_test_blackout_metric,
+    set_response_codes,
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -18,12 +22,17 @@ def preview_dev_config():
         base_url=config["eas_api_url"],
     )
 
-    _purge_functional_test_alerts(test_api_client)
-    _purge_folders_and_templates(test_api_client)
-    _purge_user_created_services(test_api_client)
+    purge_functional_test_alerts(test_api_client)
+    purge_folders_and_templates(test_api_client)
+    purge_user_created_services(test_api_client)
+
+    yield
+
+    set_response_codes()
+    put_functional_test_blackout_metric(None, False)
 
 
-def _purge_functional_test_alerts(test_api_client):
+def purge_functional_test_alerts(test_api_client):
     service = config["broadcast_service"]["service_id"]
     older_than = config["broadcast_service"]["purge_older_than"]
 
@@ -31,14 +40,14 @@ def _purge_functional_test_alerts(test_api_client):
     test_api_client.delete(url)
 
 
-def _purge_folders_and_templates(test_api_client):
+def purge_folders_and_templates(test_api_client):
     service = config["broadcast_service"]["service_id"]
 
     url = f"/service/{service}/template/purge"
     test_api_client.delete(url)
 
 
-def _purge_user_created_services(test_api_client):
+def purge_user_created_services(test_api_client):
     admin_user = config["broadcast_service"]["platform_admin"]["id"]
 
     url = f"/service/purge-services-created/{admin_user}"

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -42,7 +42,6 @@ def test_get_loopback_request_with_bad_id_returns_no_items():
     assert len(response["Items"]) == 0
 
 
-# @pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_generates_four_provider_messages(driver, api_client):
     ddbc = create_ddb_client()
@@ -203,7 +202,6 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
     cancel_alert(driver, broadcast_id)
 
 
-# @pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_with_both_azs_failing_retries_requests(driver, api_client):
     broadcast_id = str(uuid.uuid4())

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -59,9 +59,6 @@ def test_broadcast_generates_four_provider_messages(driver, api_client):
     response = api_client.get(url=url)
     assert response is not None
 
-    print(f">>> provider messages for broadcast message ID {broadcast_message_id}")
-    print(response)
-
     provider_messages = response["messages"]
     assert provider_messages is not None
     assert len(provider_messages) == 4
@@ -78,8 +75,6 @@ def test_broadcast_generates_four_provider_messages(driver, api_client):
             ExpressionAttributeValues={":RequestId": {"S": request_id}},
             ConsistentRead=True,
         )
-        print(f">>> loopback requests for request ID {request_id}")
-        print(db_response)
         if len(db_response["Items"]):
             distinct_request_ids += 1
 
@@ -178,9 +173,6 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
     response = api_client.get(url=url)
     assert response is not None
 
-    print(f">>> provider messages for broadcast message ID {broadcast_message_id}")
-    print(response)
-
     provider_messages = response["messages"]
     assert provider_messages is not None
     assert len(provider_messages) == 4
@@ -195,9 +187,6 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
     )
 
     reset_response_codes(ddbc)
-
-    print(f">>> loopback requests for request ID {request_id}")
-    print(db_response)
 
     responses = db_response["Items"]
 
@@ -240,9 +229,6 @@ def test_broadcast_with_both_azs_failing_retries_requests(driver, api_client):
     response = api_client.get(url=url)
     assert response is not None
 
-    print(f">>> provider messages for broadcast message ID {broadcast_message_id}")
-    print(response)
-
     provider_messages = response["messages"]
     assert provider_messages is not None
     assert len(provider_messages) == 4
@@ -257,9 +243,6 @@ def test_broadcast_with_both_azs_failing_retries_requests(driver, api_client):
     )
 
     reset_response_codes(ddbc)
-
-    print(f">>> loopback requests for request ID {request_id}")
-    print(db_response)
 
     responses = db_response["Items"]
 
@@ -314,9 +297,6 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     response = api_client.get(url=url)
     assert response is not None
 
-    print(f">>> provider messages for broadcast message ID {broadcast_message_id}")
-    print(response)
-
     provider_messages = response["messages"]
     assert provider_messages is not None
     assert len(provider_messages) == 4
@@ -329,9 +309,6 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
         ExpressionAttributeValues={":RequestId": {"S": request_id}},
         ConsistentRead=True,
     )
-
-    print(f">>> loopback requests for request ID {request_id}")
-    print(db_response)
 
     responses = db_response["Items"]
 

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -122,7 +122,7 @@ def test_get_loopback_responses_returns_codes_for_eight_endpoints():
 def test_set_loopback_response_codes():
     ddbc = create_ddb_client()
 
-    test_code = "403"
+    test_code = 403
     set_error_response_codes(ddbc, response_code=test_code)
     for mno in PROVIDERS:
         for az in ["az1", "az2"]:
@@ -137,7 +137,7 @@ def test_set_loopback_response_codes():
                 ConsistentRead=True,
             )
             assert db_response["Count"] == 1
-            assert db_response["Items"][0]["ResponseCode"]["N"] == test_code
+            assert db_response["Items"][0]["ResponseCode"]["N"] == str(test_code)
 
     reset_response_codes(ddbc)
     for mno in PROVIDERS:
@@ -163,7 +163,7 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
     mno = "ee"
     primary_cbc = f"{mno}-az1"
     secondary_cbc = f"{mno}-az2"
-    failure_code = "500"
+    failure_code = 500
 
     ddbc = create_ddb_client()
     set_error_response_codes(ddbc, response_code=failure_code, cbc_list=[primary_cbc])
@@ -380,11 +380,11 @@ def dynamo_items_for_key_value(data, key, value, item):
     return items
 
 
-def set_error_response_codes(ddbc, response_code="200", cbc_list=None):
+def set_error_response_codes(ddbc, response_code=200, cbc_list=None):
     put_functional_test_blackout_metric(status=response_code)
     set_response_codes(ddbc=ddbc, response_code=response_code, cbc_list=cbc_list)
 
 
 def reset_response_codes(ddbc):
     set_response_codes(ddbc=ddbc)
-    put_functional_test_blackout_metric(status="200")
+    put_functional_test_blackout_metric(status=200)

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -101,6 +101,7 @@ def test_broadcast_generates_four_provider_messages(driver, api_client):
             ExpressionAttributeValues={":RequestId": {"S": request_id}},
             ConsistentRead=True,
         )
+        print(db_response)
         if len(db_response["Items"]):
             distinct_request_ids += 1
 
@@ -198,18 +199,18 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
         ExpressionAttributeValues={":RequestId": {"S": request_id}},
         ConsistentRead=True,
     )
-
+    print(db_response)
     responses = db_response["Items"]
 
-    o2_az1_response_code = _dynamo_item_for_key_value(
+    az1_response_code = _dynamo_item_for_key_value(
         responses, "MnoName", primary_cbc, "ResponseCode"
     )
-    assert o2_az1_response_code == failure_code
+    assert az1_response_code == failure_code
 
-    o2_az2_response_code = _dynamo_item_for_key_value(
+    az2_response_code = _dynamo_item_for_key_value(
         responses, "MnoName", secondary_cbc, "ResponseCode"
     )
-    assert o2_az2_response_code == success_code
+    assert az2_response_code == success_code
 
     cancel_alert(driver, broadcast_id)
 
@@ -251,7 +252,7 @@ def test_broadcast_with_both_azs_failing_retries_requests(driver, api_client):
         ExpressionAttributeValues={":RequestId": {"S": request_id}},
         ConsistentRead=True,
     )
-
+    print(db_response)
     responses = db_response["Items"]
 
     az1_response_codes = _dynamo_items_for_key_value(
@@ -317,7 +318,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
         ExpressionAttributeValues={":RequestId": {"S": request_id}},
         ConsistentRead=True,
     )
-
+    print(db_response)
     responses = db_response["Items"]
 
     az1_response_codes = _dynamo_items_for_key_value(

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -67,7 +67,7 @@ def test_get_loopback_request_with_bad_id_returns_no_items():
     assert len(response["Items"]) == 0
 
 
-@pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
+# @pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_generates_four_provider_messages(driver, api_client):
     ddbc = create_ddb_client()
@@ -214,7 +214,7 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client):
     cancel_alert(driver, broadcast_id)
 
 
-@pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
+# @pytest.mark.skip("Skip while vodafone loopback architecture issue is investigated")
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_with_both_azs_failing_retries_requests(driver, api_client):
     broadcast_id = str(uuid.uuid4())

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -411,7 +411,7 @@ def _create_cloudwatch_client():
 
         sts_session = cloudwatch_client.assume_role(
             RoleArn="arn:aws:iam::519419547532:role/mno-loopback-cloudwatch-access",
-            RoleSessionNme="access-cloudwatch-for-functional-test",
+            RoleSessionName="access-cloudwatch-for-functional-test",
         )
 
         KEY_ID = sts_session["Credentials"]["AccessKeyId"]
@@ -434,7 +434,7 @@ def _create_cloudwatch_client():
         raise Exception("Unable to assume role") from e
 
 
-def _put_functional_test_blackout_metric(cbc_list, blackout):
+def _put_functional_test_blackout_metric(cbc_list, status):
 
     if cbc_list is None:
         cbc_list = config["cbcs"].values()
@@ -449,16 +449,12 @@ def _put_functional_test_blackout_metric(cbc_list, blackout):
                         "MetricName": "FunctionalTestBlackout",
                         "Dimensions": [
                             {
-                                "Name": "MNO",
-                                "Value": mno,
-                            },
-                            {
-                                "Name": "AZ",
-                                "Value": az,
+                                "Name": "Status",
+                                "Value": status,
                             },
                         ],
                         "Unit": "Count",
-                        "Value": 0.0 if blackout else 1.0,
+                        "Value": 1 if status > 299 else 0,
                     },
                 ],
                 Namespace="FunctionalTests",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -667,7 +667,7 @@ def set_response_codes(ddbc=None, response_code="200", cbc_list=None):
         )
 
 
-def put_functional_test_blackout_metric(status):
+def put_functional_test_blackout_metric(status: int):
     try:
         cwc = create_cloudwatch_client()
         cwc.put_metric_data(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from urllib.parse import urlencode
 
+import boto3
 import requests
 from itsdangerous import URLSafeTimedSerializer
 from notifications_python_client.notifications import NotificationsAPIClient
@@ -575,3 +576,115 @@ def _url_with_token(data, url, config):
     )
     base_url = config["eas_admin_url"] + url
     return base_url + token
+
+
+def create_ddb_client():
+    try:
+        sts_client = boto3.client("sts")
+
+        sts_session = sts_client.assume_role(
+            RoleArn="arn:aws:iam::519419547532:role/mno-loopback-database-access",
+            RoleSessionName="access-loopback-for-functional-test",
+        )
+
+        KEY_ID = sts_session["Credentials"]["AccessKeyId"]
+        ACCESS_KEY = sts_session["Credentials"]["SecretAccessKey"]
+        TOKEN = sts_session["Credentials"]["SessionToken"]
+
+        try:
+            return boto3.client(
+                "dynamodb",
+                region_name="eu-west-2",
+                aws_access_key_id=KEY_ID,
+                aws_secret_access_key=ACCESS_KEY,
+                aws_session_token=TOKEN,
+            )
+
+        except Exception as e:
+            raise Exception("Unable to create DB client") from e
+
+    except Exception as e:
+        raise Exception("Unable to assume role") from e
+
+
+def create_cloudwatch_client():
+    try:
+        cloudwatch_client = boto3.client("cloudwatch")
+
+        sts_session = cloudwatch_client.assume_role(
+            RoleArn="arn:aws:iam::519419547532:role/mno-loopback-cloudwatch-access",
+            RoleSessionName="access-cloudwatch-for-functional-test",
+        )
+
+        KEY_ID = sts_session["Credentials"]["AccessKeyId"]
+        ACCESS_KEY = sts_session["Credentials"]["SecretAccessKey"]
+        TOKEN = sts_session["Credentials"]["SessionToken"]
+
+        try:
+            return boto3.client(
+                "cloudwatch",
+                region_name="eu-west-2",
+                aws_access_key_id=KEY_ID,
+                aws_secret_access_key=ACCESS_KEY,
+                aws_session_token=TOKEN,
+            )
+
+        except Exception as e:
+            raise Exception("Unable to create CloudWatch client") from e
+
+    except Exception as e:
+        raise Exception("Unable to assume role") from e
+
+
+def is_list_of_strings(arg):
+    if isinstance(arg, list):
+        return all(isinstance(item, str) for item in arg)
+    return False
+
+
+def set_response_codes(ddbc=None, response_code="200", cbc_list=None):
+    if ddbc is None:
+        ddbc = create_ddb_client()
+
+    if cbc_list is None:
+        cbc_list = config["cbcs"].keys()
+
+    if not is_list_of_strings(cbc_list):
+        print("Please provide a list of cbc identifiers")
+        return
+
+    for cbc in cbc_list:
+        ip = config["cbcs"][cbc]
+        ddbc.update_item(
+            TableName="LoopbackResponses",
+            Key={
+                "IpAddress": {"S": ip},
+            },
+            UpdateExpression="SET ResponseCode = :code",
+            ExpressionAttributeValues={
+                ":code": {"N": response_code},
+            },
+        )
+
+
+def put_functional_test_blackout_metric(status):
+    try:
+        cwc = create_cloudwatch_client()
+        cwc.put_metric_data(
+            MetricData=[
+                {
+                    "MetricName": "FunctionalTestBlackout",
+                    "Dimensions": [
+                        {
+                            "Name": "Status",
+                            "Value": status,
+                        },
+                    ],
+                    "Unit": "Count",
+                    "Value": 1 if status > 299 else 0,
+                },
+            ],
+            Namespace="FunctionalTests",
+        )
+    except BaseException:
+        print("Error sending response code metric to CW")


### PR DESCRIPTION
Uses an alarm blackout, similar to the scheduled lambda blackouts, to prevent alarms being raised during the functional test runs.