### PR TITLE
EAS-1984 Reset lambda error metrics

### DIFF
--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -5,8 +5,8 @@ import pytest
 from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
 from tests.test_utils import (
+    clear_proxy_error_alarm,
     put_functional_test_blackout_metric,
-    reset_proxy_invoke_metric,
     set_response_codes,
 )
 
@@ -38,7 +38,7 @@ def cbc_blackout():
     yield
     set_response_codes()
     time.sleep(10)
-    reset_proxy_invoke_metric()
+    clear_proxy_error_alarm()
     put_functional_test_blackout_metric(200)
 
 

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -6,6 +6,7 @@ from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
 from tests.test_utils import (
     put_functional_test_blackout_metric,
+    reset_proxy_invoke_metric,
     set_response_codes,
 )
 
@@ -37,6 +38,7 @@ def cbc_blackout():
     yield
     set_response_codes()
     time.sleep(10)
+    reset_proxy_invoke_metric()
     put_functional_test_blackout_metric(200)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -693,7 +693,13 @@ def reset_proxy_invoke_metric():
                     MetricData=[
                         {
                             "MetricName": "Errors",
-                            "FunctionName": f"{mno}-{az}-proxy",
+                            "Dimensions": [
+                                {
+                                    "Name": "FunctionName",
+                                    "Value": f"{mno}-{az}-proxy",
+                                },
+                            ],
+                            "Unit": "Count",
                             "Value": 0,
                         },
                     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -689,21 +689,11 @@ def reset_proxy_invoke_metric():
         cwc = create_cloudwatch_client()
         for mno in PROVIDERS:
             for az in ["1", "2"]:
-                cwc.put_metric_data(
-                    MetricData=[
-                        {
-                            "MetricName": "Errors",
-                            "Dimensions": [
-                                {
-                                    "Name": "FunctionName",
-                                    "Value": f"{mno}-{az}-proxy",
-                                },
-                            ],
-                            "Unit": "Count",
-                            "Value": 0,
-                        },
-                    ],
-                    Namespace="AWS/Lambda",
+                cwc.set_alarm_state(
+                    AlarmName=f"{mno}-{az}-proxy-error",
+                    StateValue="OK",
+                    StateReason="Functional test alarm reset",
                 )
+
     except BaseException as e:
         raise Exception("Error writing proxy count metric to CW") from e

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -684,7 +684,7 @@ def put_functional_test_blackout_metric(status: int):
         raise Exception("Error sending response code metric to CW") from e
 
 
-def reset_proxy_invoke_metric():
+def clear_proxy_error_alarm():
     try:
         cwc = create_cloudwatch_client()
         for mno in PROVIDERS:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -682,3 +682,22 @@ def put_functional_test_blackout_metric(status: int):
         )
     except BaseException as e:
         raise Exception("Error sending response code metric to CW") from e
+
+
+def reset_proxy_invoke_metric():
+    try:
+        cwc = create_cloudwatch_client()
+        for mno in PROVIDERS:
+            for az in ["1", "2"]:
+                cwc.put_metric_data(
+                    MetricData=[
+                        {
+                            "MetricName": "Errors",
+                            "FunctionName": f"{mno}-{az}-proxy",
+                            "Value": 0,
+                        },
+                    ],
+                    Namespace="AWS/Lambda",
+                )
+    except BaseException as e:
+        raise Exception("Error writing proxy count metric to CW") from e

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -694,6 +694,5 @@ def reset_proxy_invoke_metric():
                     StateValue="OK",
                     StateReason="Functional test alarm reset",
                 )
-
     except BaseException as e:
         raise Exception("Error writing proxy count metric to CW") from e


### PR DESCRIPTION
The lambda error metric is reset after the cbc-integration tests.