### PR TITLE
EAS-2419 Reason for rejection

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -61,13 +54,13 @@ phases:
         else
           echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
         fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
+      # - make test-platform-admin-flow; exit 0
+      # - make test-authentication-flow; exit 0
+      # - make test-links-and-cookies; exit 0
+      # - make test-template-flow; exit 0
+      # - make test-user-operations; exit 0
+      # - make test-throttling; exit 0
+      # - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,12 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
       session-timeout
 
 phases:
@@ -55,12 +61,12 @@ phases:
         else
           echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
         fi
-      # - make test-platform-admin-flow; exit 0
-      # - make test-authentication-flow; exit 0
-      # - make test-links-and-cookies; exit 0
-      # - make test-template-flow; exit 0
-      # - make test-user-operations; exit 0
-      # - make test-throttling; exit 0
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
       - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,7 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      session-timeout
 
 phases:
   install:
@@ -60,7 +61,7 @@ phases:
       # - make test-template-flow; exit 0
       # - make test-user-operations; exit 0
       # - make test-throttling; exit 0
-      # - make test-session-timeout; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,12 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
       session-timeout
 
 phases:
@@ -61,12 +55,12 @@ phases:
         else
           echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
         fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
+      # - make test-platform-admin-flow; exit 0
+      # - make test-authentication-flow; exit 0
+      # - make test-links-and-cookies; exit 0
+      # - make test-template-flow; exit 0
+      # - make test-user-operations; exit 0
+      # - make test-throttling; exit 0
       - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -598,7 +598,7 @@ def test_reject_alert_with_reason(driver):
 
     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
 
-    alert_page_with_rejection = RejectionForm()
+    alert_page_with_rejection = RejectionForm(driver)
     alert_page_with_rejection.click_open_reject_detail()
     assert alert_page_with_rejection.rejection_details_is_open()
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,533 +1,510 @@
-import time
 import uuid
-from datetime import datetime, timedelta
 
 import pytest
 
 from config import config
-from tests.functional.preview_and_dev.sample_cap_xml import (
-    ALERT_XML,
-    CANCEL_XML,
-)
-from tests.pages import (
-    BasePage,
-    BroadcastFreeformPage,
-    DashboardPage,
-    ShowTemplatesPage,
-)
-from tests.pages.pages import (
-    ChooseCoordinateArea,
-    ChooseCoordinatesType,
-    RejectionForm,
-    SearchPostcodePage,
-)
+from tests.pages import BasePage, BroadcastFreeformPage, DashboardPage
+from tests.pages.pages import RejectionForm
 from tests.pages.rollups import sign_in
-from tests.test_utils import (
-    check_alert_is_published_on_govuk_alerts,
-    convert_naive_utc_datetime_to_cap_standard_string,
-    create_broadcast_template,
-    delete_template,
-    go_to_templates_page,
-)
 
 test_group_name = "broadcast-flow"
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-
-    prepare_alert_pages.click_element_by_link_text(
-        "Preview alert"
-    )  # Remove once alert duration added back in
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page("Cokeham")
-    assert prepare_alert_pages.text_is_on_page("Eastbrook")
-
-    # prepare_alert_pages.click_element_by_link_text("Continue")
-    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    # prepare_alert_pages.click_continue()  # click "Preview alert"
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    prepare_alert_pages.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_template(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    go_to_templates_page(driver, service="broadcast_service")
-    template_name = "test broadcast" + str(uuid.uuid4())
-    content = "This is a test only."
-    create_broadcast_template(driver, name=template_name, content=content)
-
-    dashboard_page = DashboardPage(driver)
-    dashboard_page.go_to_dashboard_for_service(
-        service_id=config["broadcast_service"]["id"]
-    )
-
-    dashboard_page.click_element_by_link_text("Current alerts")
-
-    current_alerts_page = BasePage(driver)
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="template")
-    new_alert_page.click_continue()
-
-    templates_page = ShowTemplatesPage(driver)
-    templates_page.click_template_by_link_text(template_name)
-
-    templates_page.click_element_by_link_text("Get ready to send")
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text(
-        "Preview alert"
-    )  # Remove once alert duration added back in
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page("Cokeham")
-    assert prepare_alert_pages.text_is_on_page("Eastbrook")
-
-    # prepare_alert_pages.click_element_by_link_text("Continue")
-    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-    # prepare_alert_pages.click_continue()  # click "Preview alert"
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{template_name} is waiting for approval"
-    )
-
-    prepare_alert_pages.click_element_by_link_text("Discard this alert")
-    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.text_is_on_page(template_name)
-
-    delete_template(driver, template_name, service="broadcast_service")
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
-
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
-
-    sign_in(driver, account_type="broadcast_approve_user")
-    page = BasePage(driver)
-    page.click_element_by_link_text("Current alerts")
-    page.click_element_by_link_text(event)
-
-    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
-
-    reject_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(reject_broadcast_xml)
-
-    time.sleep(10)
-    page.click_element_by_link_text("Rejected alerts")
-    assert page.text_is_on_page(event)
-
-    page.get()
-    page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
-
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
-
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    page = BasePage(driver)
-    page.click_element_by_link_text("Current alerts")
-    page.click_element_by_link_text(event)
-    page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    page.click_continue()
-
-    assert page.text_is_on_page("since today at")
-
-    alert_page_url = page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    cancel_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
-
-    # go back to the page for the current alert
-    time.sleep(10)
-    page.get(alert_page_url)
-
-    # assert that it's now cancelled
-    assert page.text_is_on_page("Stopped by an API call")
-    page.click_element_by_link_text("Past alerts")
-    assert page.text_is_on_page(event)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    page.get()
-    page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Postcode areas")
-    # This is where it varies
-    search_postcode_page = SearchPostcodePage(driver)
-    postcode_to_search = "BD1 1EE"
-    radius_to_add = "5"
-    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-    search_postcode_page.click_search()
-    # assert areas appear here
-
-    search_postcode_page.click_preview()
-
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page(
-        "5km around the postcode BD1 1EE in Bradford"
-    )
-
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    prepare_alert_pages.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-@pytest.mark.parametrize(
-    "coordinate_type, post_data, expected_area_description",
-    (
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "416567",
-                "second_coordinate": "432994",
-                "radius": "3",
-            },
-            "3km around the easting of 416567 and the northing of 432994 in Bradford",
-        ),
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "419763",
-                "second_coordinate": "456038",
-                "radius": "5",
-            },
-            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-            "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-        ),
-    ),
-)
-def test_prepare_broadcast_with_new_content_for_coordinate_area(
-    driver, coordinate_type, post_data, expected_area_description
-):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast{test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Coordinates")
-    # This is where it varies
-    choose_type_page = ChooseCoordinatesType(driver)
-    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-    choose_type_page.click_continue()
-
-    choose_coordinate_area_page = ChooseCoordinateArea(driver)
-    choose_coordinate_area_page.create_coordinate_area(
-        post_data["first_coordinate"],
-        post_data["second_coordinate"],
-        post_data["radius"],
-    )
-    choose_coordinate_area_page.click_search()
-    choose_coordinate_area_page.click_preview()
-
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page(expected_area_description)
-
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    prepare_alert_pages.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+
+#     prepare_alert_pages.click_element_by_link_text(
+#         "Preview alert"
+#     )  # Remove once alert duration added back in
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page("Cokeham")
+#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
+
+#     # prepare_alert_pages.click_element_by_link_text("Continue")
+#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+#     # prepare_alert_pages.click_continue()  # click "Preview alert"
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_template(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     go_to_templates_page(driver, service="broadcast_service")
+#     template_name = "test broadcast" + str(uuid.uuid4())
+#     content = "This is a test only."
+#     create_broadcast_template(driver, name=template_name, content=content)
+
+#     dashboard_page = DashboardPage(driver)
+#     dashboard_page.go_to_dashboard_for_service(
+#         service_id=config["broadcast_service"]["id"]
+#     )
+
+#     dashboard_page.click_element_by_link_text("Current alerts")
+
+#     current_alerts_page = BasePage(driver)
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="template")
+#     new_alert_page.click_continue()
+
+#     templates_page = ShowTemplatesPage(driver)
+#     templates_page.click_template_by_link_text(template_name)
+
+#     templates_page.click_element_by_link_text("Get ready to send")
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text(
+#         "Preview alert"
+#     )  # Remove once alert duration added back in
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page("Cokeham")
+#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
+
+#     # prepare_alert_pages.click_element_by_link_text("Continue")
+#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+#     # prepare_alert_pages.click_continue()  # click "Preview alert"
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{template_name} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
+#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.text_is_on_page(template_name)
+
+#     delete_template(driver, template_name, service="broadcast_service")
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.utcnow() - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
+
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
+
+#     sign_in(driver, account_type="broadcast_approve_user")
+#     page = BasePage(driver)
+#     page.click_element_by_link_text("Current alerts")
+#     page.click_element_by_link_text(event)
+
+#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+
+#     reject_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
+
+#     time.sleep(10)
+#     page.click_element_by_link_text("Rejected alerts")
+#     assert page.text_is_on_page(event)
+
+#     page.get()
+#     page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.utcnow() - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
+
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
+
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     page = BasePage(driver)
+#     page.click_element_by_link_text("Current alerts")
+#     page.click_element_by_link_text(event)
+#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     page.click_continue()
+
+#     assert page.text_is_on_page("since today at")
+
+#     alert_page_url = page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     cancel_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+#     # go back to the page for the current alert
+#     time.sleep(10)
+#     page.get(alert_page_url)
+
+#     # assert that it's now cancelled
+#     assert page.text_is_on_page("Stopped by an API call")
+#     page.click_element_by_link_text("Past alerts")
+#     assert page.text_is_on_page(event)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     page.get()
+#     page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
+#     # This is where it varies
+#     search_postcode_page = SearchPostcodePage(driver)
+#     postcode_to_search = "BD1 1EE"
+#     radius_to_add = "5"
+#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+#     search_postcode_page.click_search()
+#     # assert areas appear here
+
+#     search_postcode_page.click_preview()
+
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page(
+#         "5km around the postcode BD1 1EE in Bradford"
+#     )
+
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# @pytest.mark.parametrize(
+#     "coordinate_type, post_data, expected_area_description",
+#     (
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "416567",
+#                 "second_coordinate": "432994",
+#                 "radius": "3",
+#             },
+#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
+#         ),
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "419763",
+#                 "second_coordinate": "456038",
+#                 "radius": "5",
+#             },
+#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+#         ),
+#     ),
+# )
+# def test_prepare_broadcast_with_new_content_for_coordinate_area(
+#     driver, coordinate_type, post_data, expected_area_description
+# ):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast{test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Coordinates")
+#     # This is where it varies
+#     choose_type_page = ChooseCoordinatesType(driver)
+#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+#     choose_type_page.click_continue()
+
+#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
+#     choose_coordinate_area_page.create_coordinate_area(
+#         post_data["first_coordinate"],
+#         post_data["second_coordinate"],
+#         post_data["radius"],
+#     )
+#     choose_coordinate_area_page.click_search()
+#     choose_coordinate_area_page.click_preview()
+
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page(expected_area_description)
+
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -587,7 +587,7 @@ def test_reject_alert_with_reason(driver):
     # Assert errors appear
     assert (
         alert_page_with_rejection.get_rejection_form_errors()
-        == "Enter rejection reason"
+        == "Enter the reason for rejecting the alert"
     )
 
     # With rejection reason

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -576,6 +576,7 @@ def test_reject_alert_with_reason(driver):
     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
 
     alert_page_with_rejection = RejectionForm(driver)
+    assert alert_page_with_rejection.rejection_details_is_closed()
     alert_page_with_rejection.click_open_reject_detail()
     assert alert_page_with_rejection.rejection_details_is_open()
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -15,7 +15,12 @@ from tests.pages import (
     DashboardPage,
     ShowTemplatesPage,
 )
-from tests.pages.pages import RejectionForm
+from tests.pages.pages import (
+    ChooseCoordinateArea,
+    ChooseCoordinatesType,
+    RejectionForm,
+    SearchPostcodePage,
+)
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
     check_alert_is_published_on_govuk_alerts,
@@ -229,300 +234,300 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
     page.sign_out()
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.utcnow() - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
+@pytest.mark.xdist_group(name=test_group_name)
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.utcnow() - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
 
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
 
-#     sign_in(driver, account_type="broadcast_approve_user")
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     page = BasePage(driver)
-#     page.click_element_by_link_text("Current alerts")
-#     page.click_element_by_link_text(event)
-#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     page.click_continue()
+    page = BasePage(driver)
+    page.click_element_by_link_text("Current alerts")
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_continue()
 
-#     assert page.text_is_on_page("since today at")
+    assert page.text_is_on_page("since today at")
 
-#     alert_page_url = page.current_url
+    alert_page_url = page.current_url
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
 
-#     cancel_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-#     # go back to the page for the current alert
-#     time.sleep(10)
-#     page.get(alert_page_url)
+    # go back to the page for the current alert
+    time.sleep(10)
+    page.get(alert_page_url)
 
-#     # assert that it's now cancelled
-#     assert page.text_is_on_page("Stopped by an API call")
-#     page.click_element_by_link_text("Past alerts")
-#     assert page.text_is_on_page(event)
+    # assert that it's now cancelled
+    assert page.text_is_on_page("Stopped by an API call")
+    page.click_element_by_link_text("Past alerts")
+    assert page.text_is_on_page(event)
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-#     page.get()
-#     page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
-#     # This is where it varies
-#     search_postcode_page = SearchPostcodePage(driver)
-#     postcode_to_search = "BD1 1EE"
-#     radius_to_add = "5"
-#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-#     search_postcode_page.click_search()
-#     # assert areas appear here
-
-#     search_postcode_page.click_preview()
-
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page(
-#         "5km around the postcode BD1 1EE in Bradford"
-#     )
-
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+    page.get()
+    page.sign_out()
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# @pytest.mark.parametrize(
-#     "coordinate_type, post_data, expected_area_description",
-#     (
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "416567",
-#                 "second_coordinate": "432994",
-#                 "radius": "3",
-#             },
-#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
-#         ),
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "419763",
-#                 "second_coordinate": "456038",
-#                 "radius": "5",
-#             },
-#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-#         ),
-#     ),
-# )
-# def test_prepare_broadcast_with_new_content_for_coordinate_area(
-#     driver, coordinate_type, post_data, expected_area_description
-# ):
-#     sign_in(driver, account_type="broadcast_create_user")
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+    sign_in(driver, account_type="broadcast_create_user")
 
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
 
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast{test_uuid}"
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
 
-#     current_alerts_page.click_element_by_link_text("Create new alert")
+    current_alerts_page.click_element_by_link_text("Create new alert")
 
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
 
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
 
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Coordinates")
-#     # This is where it varies
-#     choose_type_page = ChooseCoordinatesType(driver)
-#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-#     choose_type_page.click_continue()
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Postcode areas")
+    # This is where it varies
+    search_postcode_page = SearchPostcodePage(driver)
+    postcode_to_search = "BD1 1EE"
+    radius_to_add = "5"
+    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+    search_postcode_page.click_search()
+    # assert areas appear here
 
-#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
-#     choose_coordinate_area_page.create_coordinate_area(
-#         post_data["first_coordinate"],
-#         post_data["second_coordinate"],
-#         post_data["radius"],
-#     )
-#     choose_coordinate_area_page.click_search()
-#     choose_coordinate_area_page.click_preview()
+    search_postcode_page.click_preview()
 
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page(expected_area_description)
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page(
+        "5km around the postcode BD1 1EE in Bradford"
+    )
 
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
 
-#     prepare_alert_pages.sign_out()
+    prepare_alert_pages.sign_out()
 
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
 
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
 
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
 
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "coordinate_type, post_data, expected_area_description",
+    (
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "416567",
+                "second_coordinate": "432994",
+                "radius": "3",
+            },
+            "3km around the easting of 416567 and the northing of 432994 in Bradford",
+        ),
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "419763",
+                "second_coordinate": "456038",
+                "radius": "5",
+            },
+            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+            "3km around 53.793 latitude, -1.75 longitude in Bradford",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_new_content_for_coordinate_area(
+    driver, coordinate_type, post_data, expected_area_description
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast{test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Coordinates")
+    # This is where it varies
+    choose_type_page = ChooseCoordinatesType(driver)
+    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+    choose_type_page.click_continue()
+
+    choose_coordinate_area_page = ChooseCoordinateArea(driver)
+    choose_coordinate_area_page.create_coordinate_area(
+        post_data["first_coordinate"],
+        post_data["second_coordinate"],
+        post_data["radius"],
+    )
+    choose_coordinate_area_page.click_search()
+    choose_coordinate_area_page.click_preview()
+
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page(expected_area_description)
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    prepare_alert_pages.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,510 +1,533 @@
+import time
 import uuid
+from datetime import datetime, timedelta
 
 import pytest
 
 from config import config
-from tests.pages import BasePage, BroadcastFreeformPage, DashboardPage
-from tests.pages.pages import RejectionForm
+from tests.functional.preview_and_dev.sample_cap_xml import (
+    ALERT_XML,
+    CANCEL_XML,
+)
+from tests.pages import (
+    BasePage,
+    BroadcastFreeformPage,
+    DashboardPage,
+    ShowTemplatesPage,
+)
+from tests.pages.pages import (
+    ChooseCoordinateArea,
+    ChooseCoordinatesType,
+    RejectionForm,
+    SearchPostcodePage,
+)
 from tests.pages.rollups import sign_in
+from tests.test_utils import (
+    check_alert_is_published_on_govuk_alerts,
+    convert_naive_utc_datetime_to_cap_standard_string,
+    create_broadcast_template,
+    delete_template,
+    go_to_templates_page,
+)
 
 test_group_name = "broadcast-flow"
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-
-#     prepare_alert_pages.click_element_by_link_text(
-#         "Preview alert"
-#     )  # Remove once alert duration added back in
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page("Cokeham")
-#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
-
-#     # prepare_alert_pages.click_element_by_link_text("Continue")
-#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-#     # prepare_alert_pages.click_continue()  # click "Preview alert"
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_template(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     go_to_templates_page(driver, service="broadcast_service")
-#     template_name = "test broadcast" + str(uuid.uuid4())
-#     content = "This is a test only."
-#     create_broadcast_template(driver, name=template_name, content=content)
-
-#     dashboard_page = DashboardPage(driver)
-#     dashboard_page.go_to_dashboard_for_service(
-#         service_id=config["broadcast_service"]["id"]
-#     )
-
-#     dashboard_page.click_element_by_link_text("Current alerts")
-
-#     current_alerts_page = BasePage(driver)
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="template")
-#     new_alert_page.click_continue()
-
-#     templates_page = ShowTemplatesPage(driver)
-#     templates_page.click_template_by_link_text(template_name)
-
-#     templates_page.click_element_by_link_text("Get ready to send")
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text(
-#         "Preview alert"
-#     )  # Remove once alert duration added back in
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page("Cokeham")
-#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
-
-#     # prepare_alert_pages.click_element_by_link_text("Continue")
-#     # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
-#     # prepare_alert_pages.click_continue()  # click "Preview alert"
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{template_name} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
-#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.text_is_on_page(template_name)
-
-#     delete_template(driver, template_name, service="broadcast_service")
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.utcnow() - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
-
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
-
-#     sign_in(driver, account_type="broadcast_approve_user")
-#     page = BasePage(driver)
-#     page.click_element_by_link_text("Current alerts")
-#     page.click_element_by_link_text(event)
-
-#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
-
-#     reject_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
-
-#     time.sleep(10)
-#     page.click_element_by_link_text("Rejected alerts")
-#     assert page.text_is_on_page(event)
-
-#     page.get()
-#     page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.utcnow() - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
-
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
-
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     page = BasePage(driver)
-#     page.click_element_by_link_text("Current alerts")
-#     page.click_element_by_link_text(event)
-#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     page.click_continue()
-
-#     assert page.text_is_on_page("since today at")
-
-#     alert_page_url = page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     cancel_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
-
-#     # go back to the page for the current alert
-#     time.sleep(10)
-#     page.get(alert_page_url)
-
-#     # assert that it's now cancelled
-#     assert page.text_is_on_page("Stopped by an API call")
-#     page.click_element_by_link_text("Past alerts")
-#     assert page.text_is_on_page(event)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     page.get()
-#     page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
-#     # This is where it varies
-#     search_postcode_page = SearchPostcodePage(driver)
-#     postcode_to_search = "BD1 1EE"
-#     radius_to_add = "5"
-#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-#     search_postcode_page.click_search()
-#     # assert areas appear here
-
-#     search_postcode_page.click_preview()
-
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page(
-#         "5km around the postcode BD1 1EE in Bradford"
-#     )
-
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# @pytest.mark.parametrize(
-#     "coordinate_type, post_data, expected_area_description",
-#     (
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "416567",
-#                 "second_coordinate": "432994",
-#                 "radius": "3",
-#             },
-#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
-#         ),
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "419763",
-#                 "second_coordinate": "456038",
-#                 "radius": "5",
-#             },
-#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-#         ),
-#     ),
-# )
-# def test_prepare_broadcast_with_new_content_for_coordinate_area(
-#     driver, coordinate_type, post_data, expected_area_description
-# ):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast{test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Coordinates")
-#     # This is where it varies
-#     choose_type_page = ChooseCoordinatesType(driver)
-#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-#     choose_type_page.click_continue()
-
-#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
-#     choose_coordinate_area_page.create_coordinate_area(
-#         post_data["first_coordinate"],
-#         post_data["second_coordinate"],
-#         post_data["radius"],
-#     )
-#     choose_coordinate_area_page.click_search()
-#     choose_coordinate_area_page.click_preview()
-
-#     # here check if selected areas displayed
-#     assert prepare_alert_pages.text_is_on_page(expected_area_description)
-
-#     prepare_alert_pages.click_continue()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     landing_page = BasePage(driver)
-#     if not landing_page.text_is_on_page("Current alerts"):
-#         landing_page.click_element_by_link_text("Switch service")
-#         choose_service_page = BasePage(driver)
-#         choose_service_page.click_element_by_link_text(
-#             config["broadcast_service"]["service_name"]
-#         )
-#     else:
-#         dashboard_page = DashboardPage(driver)
-#         dashboard_page.click_element_by_link_text("Current alerts")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_continue()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_continue()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview alert"
+    )  # Remove once alert duration added back in
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page("Cokeham")
+    assert prepare_alert_pages.text_is_on_page("Eastbrook")
+
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview alert"
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    prepare_alert_pages.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_template(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    go_to_templates_page(driver, service="broadcast_service")
+    template_name = "test broadcast" + str(uuid.uuid4())
+    content = "This is a test only."
+    create_broadcast_template(driver, name=template_name, content=content)
+
+    dashboard_page = DashboardPage(driver)
+    dashboard_page.go_to_dashboard_for_service(
+        service_id=config["broadcast_service"]["id"]
+    )
+
+    dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page = BasePage(driver)
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="template")
+    new_alert_page.click_continue()
+
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
+
+    templates_page.click_element_by_link_text("Get ready to send")
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview alert"
+    )  # Remove once alert duration added back in
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page("Cokeham")
+    assert prepare_alert_pages.text_is_on_page("Eastbrook")
+
+    # prepare_alert_pages.click_element_by_link_text("Continue")
+    # prepare_alert_pages.select_checkbox_or_radio(value="PT30M")
+    # prepare_alert_pages.click_continue()  # click "Preview alert"
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{template_name} is waiting for approval"
+    )
+
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.text_is_on_page(template_name)
+
+    delete_template(driver, template_name, service="broadcast_service")
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.utcnow() - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
+
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type="broadcast_approve_user")
+    page = BasePage(driver)
+    page.click_element_by_link_text("Current alerts")
+    page.click_element_by_link_text(event)
+
+    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+
+    reject_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(reject_broadcast_xml)
+
+    time.sleep(10)
+    page.click_element_by_link_text("Rejected alerts")
+    assert page.text_is_on_page(event)
+
+    page.get()
+    page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.utcnow() - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
+
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    page = BasePage(driver)
+    page.click_element_by_link_text("Current alerts")
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_continue()
+
+    assert page.text_is_on_page("since today at")
+
+    alert_page_url = page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+    # go back to the page for the current alert
+    time.sleep(10)
+    page.get(alert_page_url)
+
+    # assert that it's now cancelled
+    assert page.text_is_on_page("Stopped by an API call")
+    page.click_element_by_link_text("Past alerts")
+    assert page.text_is_on_page(event)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    page.get()
+    page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Postcode areas")
+    # This is where it varies
+    search_postcode_page = SearchPostcodePage(driver)
+    postcode_to_search = "BD1 1EE"
+    radius_to_add = "5"
+    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+    search_postcode_page.click_search()
+    # assert areas appear here
+
+    search_postcode_page.click_preview()
+
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page(
+        "5km around the postcode BD1 1EE in Bradford"
+    )
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    prepare_alert_pages.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "coordinate_type, post_data, expected_area_description",
+    (
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "416567",
+                "second_coordinate": "432994",
+                "radius": "3",
+            },
+            "3km around the easting of 416567 and the northing of 432994 in Bradford",
+        ),
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "419763",
+                "second_coordinate": "456038",
+                "radius": "5",
+            },
+            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+            "3km around 53.793 latitude, -1.75 longitude in Bradford",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_new_content_for_coordinate_area(
+    driver, coordinate_type, post_data, expected_area_description
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast{test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Coordinates")
+    # This is where it varies
+    choose_type_page = ChooseCoordinatesType(driver)
+    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+    choose_type_page.click_continue()
+
+    choose_coordinate_area_page = ChooseCoordinateArea(driver)
+    choose_coordinate_area_page.create_coordinate_area(
+        post_data["first_coordinate"],
+        post_data["second_coordinate"],
+        post_data["radius"],
+    )
+    choose_coordinate_area_page.click_search()
+    choose_coordinate_area_page.click_preview()
+
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page(expected_area_description)
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    prepare_alert_pages.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_continue()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_continue()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -587,7 +587,7 @@ def test_reject_alert_with_reason(driver):
     # Assert errors appear
     assert (
         alert_page_with_rejection.get_rejection_form_errors()
-        == "Enter the reason for rejecting the alert"
+        == "Error:\nEnter the reason for rejecting the alert"
     )
 
     # With rejection reason

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -585,7 +585,10 @@ def test_reject_alert_with_reason(driver):
     alert_page_with_rejection.click_reject_alert()
 
     # Assert errors appear
-    assert alert_page_with_rejection.get_errors() == "Enter rejection reason"
+    assert (
+        alert_page_with_rejection.get_rejection_form_errors()
+        == "Enter rejection reason"
+    )
 
     # With rejection reason
     rejection_reason = "This is a test rejection reason."

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -15,12 +15,7 @@ from tests.pages import (
     DashboardPage,
     ShowTemplatesPage,
 )
-from tests.pages.pages import (
-    ChooseCoordinateArea,
-    ChooseCoordinatesType,
-    RejectionForm,
-    SearchPostcodePage,
-)
+from tests.pages.pages import RejectionForm
 from tests.pages.rollups import sign_in
 from tests.test_utils import (
     check_alert_is_published_on_govuk_alerts,
@@ -234,300 +229,300 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
     page.sign_out()
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.utcnow() - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
 
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
 
-    sign_in(driver, account_type="broadcast_approve_user")
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    page = BasePage(driver)
-    page.click_element_by_link_text("Current alerts")
-    page.click_element_by_link_text(event)
-    page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    page.click_continue()
+#     page = BasePage(driver)
+#     page.click_element_by_link_text("Current alerts")
+#     page.click_element_by_link_text(event)
+#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     page.click_continue()
 
-    assert page.text_is_on_page("since today at")
+#     assert page.text_is_on_page("since today at")
 
-    alert_page_url = page.current_url
+#     alert_page_url = page.current_url
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
 
-    cancel_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+#     cancel_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-    # go back to the page for the current alert
-    time.sleep(10)
-    page.get(alert_page_url)
+#     # go back to the page for the current alert
+#     time.sleep(10)
+#     page.get(alert_page_url)
 
-    # assert that it's now cancelled
-    assert page.text_is_on_page("Stopped by an API call")
-    page.click_element_by_link_text("Past alerts")
-    assert page.text_is_on_page(event)
+#     # assert that it's now cancelled
+#     assert page.text_is_on_page("Stopped by an API call")
+#     page.click_element_by_link_text("Past alerts")
+#     assert page.text_is_on_page(event)
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-    page.get()
-    page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Postcode areas")
-    # This is where it varies
-    search_postcode_page = SearchPostcodePage(driver)
-    postcode_to_search = "BD1 1EE"
-    radius_to_add = "5"
-    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-    search_postcode_page.click_search()
-    # assert areas appear here
-
-    search_postcode_page.click_preview()
-
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page(
-        "5km around the postcode BD1 1EE in Bradford"
-    )
-
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    prepare_alert_pages.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+#     page.get()
+#     page.sign_out()
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-@pytest.mark.parametrize(
-    "coordinate_type, post_data, expected_area_description",
-    (
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "416567",
-                "second_coordinate": "432994",
-                "radius": "3",
-            },
-            "3km around the easting of 416567 and the northing of 432994 in Bradford",
-        ),
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "419763",
-                "second_coordinate": "456038",
-                "radius": "5",
-            },
-            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-            "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-        ),
-    ),
-)
-def test_prepare_broadcast_with_new_content_for_coordinate_area(
-    driver, coordinate_type, post_data, expected_area_description
-):
-    sign_in(driver, account_type="broadcast_create_user")
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
 
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
 
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast{test_uuid}"
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
 
-    current_alerts_page.click_element_by_link_text("Create new alert")
+#     current_alerts_page.click_element_by_link_text("Create new alert")
 
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
 
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
 
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Coordinates")
-    # This is where it varies
-    choose_type_page = ChooseCoordinatesType(driver)
-    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-    choose_type_page.click_continue()
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
+#     # This is where it varies
+#     search_postcode_page = SearchPostcodePage(driver)
+#     postcode_to_search = "BD1 1EE"
+#     radius_to_add = "5"
+#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+#     search_postcode_page.click_search()
+#     # assert areas appear here
 
-    choose_coordinate_area_page = ChooseCoordinateArea(driver)
-    choose_coordinate_area_page.create_coordinate_area(
-        post_data["first_coordinate"],
-        post_data["second_coordinate"],
-        post_data["radius"],
-    )
-    choose_coordinate_area_page.click_search()
-    choose_coordinate_area_page.click_preview()
+#     search_postcode_page.click_preview()
 
-    # here check if selected areas displayed
-    assert prepare_alert_pages.text_is_on_page(expected_area_description)
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page(
+#         "5km around the postcode BD1 1EE in Bradford"
+#     )
 
-    prepare_alert_pages.click_continue()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
 
-    prepare_alert_pages.sign_out()
+#     prepare_alert_pages.sign_out()
 
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    landing_page = BasePage(driver)
-    if not landing_page.text_is_on_page("Current alerts"):
-        landing_page.click_element_by_link_text("Switch service")
-        choose_service_page = BasePage(driver)
-        choose_service_page.click_element_by_link_text(
-            config["broadcast_service"]["service_name"]
-        )
-    else:
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.click_element_by_link_text("Current alerts")
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
 
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_continue()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
 
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
 
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_continue()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# @pytest.mark.parametrize(
+#     "coordinate_type, post_data, expected_area_description",
+#     (
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "416567",
+#                 "second_coordinate": "432994",
+#                 "radius": "3",
+#             },
+#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
+#         ),
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "419763",
+#                 "second_coordinate": "456038",
+#                 "radius": "5",
+#             },
+#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+#         ),
+#     ),
+# )
+# def test_prepare_broadcast_with_new_content_for_coordinate_area(
+#     driver, coordinate_type, post_data, expected_area_description
+# ):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast{test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Coordinates")
+#     # This is where it varies
+#     choose_type_page = ChooseCoordinatesType(driver)
+#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+#     choose_type_page.click_continue()
+
+#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
+#     choose_coordinate_area_page.create_coordinate_area(
+#         post_data["first_coordinate"],
+#         post_data["second_coordinate"],
+#         post_data["radius"],
+#     )
+#     choose_coordinate_area_page.click_search()
+#     choose_coordinate_area_page.click_preview()
+
+#     # here check if selected areas displayed
+#     assert prepare_alert_pages.text_is_on_page(expected_area_description)
+
+#     prepare_alert_pages.click_continue()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     landing_page = BasePage(driver)
+#     if not landing_page.text_is_on_page("Current alerts"):
+#         landing_page.click_element_by_link_text("Switch service")
+#         choose_service_page = BasePage(driver)
+#         choose_service_page.click_element_by_link_text(
+#             config["broadcast_service"]["service_name"]
+#         )
+#     else:
+#         dashboard_page = DashboardPage(driver)
+#         dashboard_page.click_element_by_link_text("Current alerts")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_continue()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_continue()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -18,6 +18,7 @@ from tests.pages import (
 from tests.pages.pages import (
     ChooseCoordinateArea,
     ChooseCoordinatesType,
+    RejectionForm,
     SearchPostcodePage,
 )
 from tests.pages.rollups import sign_in
@@ -527,3 +528,97 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
 
     current_alerts_page.get()
     current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_reject_alert_with_reason(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast{test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+
+    prepare_alert_pages.click_element_by_link_text(
+        "Preview alert"
+    )  # Remove once alert duration added back in
+    # here check if selected areas displayed
+    assert prepare_alert_pages.text_is_on_page("Cokeham")
+    assert prepare_alert_pages.text_is_on_page("Eastbrook")
+
+    prepare_alert_pages.click_continue()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    prepare_alert_pages.sign_out()
+
+    # reject the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    landing_page = BasePage(driver)
+    if not landing_page.text_is_on_page("Current alerts"):
+        landing_page.click_element_by_link_text("Switch service")
+        choose_service_page = BasePage(driver)
+        choose_service_page.click_element_by_link_text(
+            config["broadcast_service"]["service_name"]
+        )
+    else:
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.click_element_by_link_text("Current alerts")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_rejection = RejectionForm()
+    alert_page_with_rejection.click_open_reject_detail()
+    assert alert_page_with_rejection.rejection_details_is_open()
+
+    # Without rejection reason
+    rejection_reason = ""
+    alert_page_with_rejection.click_reject_alert()
+
+    # Assert errors appear
+    assert alert_page_with_rejection.get_errors() == "Enter rejection reason"
+
+    # With rejection reason
+    rejection_reason = "This is a test rejection reason."
+    alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
+    alert_page_with_rejection.click_reject_alert()
+
+    assert landing_page.text_is_on_page("Current alerts")
+    landing_page.click_element_by_link_text("Rejected alerts")
+
+    rejected_alerts_page = BasePage(driver)
+
+    assert rejected_alerts_page.text_is_on_page(broadcast_title)
+    assert rejected_alerts_page.text_is_on_page(rejection_reason)
+    assert rejected_alerts_page.text_is_on_page(rejection_reason)

--- a/tests/functional/preview_and_dev/test_session_timeout.py
+++ b/tests/functional/preview_and_dev/test_session_timeout.py
@@ -87,13 +87,13 @@ def test_dialogs_appears_and_signs_user_out_at_max_session_lifetime(driver):
     assert dashboard_with_dialogs_page.is_expiry_dialog_hidden()
     time.sleep(10)
     sign_in_page = SignInPage(driver)
-    if sign_in_page.text_is_on_page("You’ve been signed out"):
+    if sign_in_page.is_text_present_on_page("You’ve been signed out"):
         assert sign_in_page.text_is_on_page(
             "We do this every hour to keep your information secure. Sign back in to start a new session"
         )
         assert dashboard_with_dialogs_page.url_contains("status=expired")
         assert dashboard_with_dialogs_page.url_contains("templates")
-    elif sign_in_page.text_is_on_page("You need to sign in again"):
+    elif sign_in_page.is_text_present_on_page("You need to sign in again"):
         assert sign_in_page.text_is_on_page(
             "We signed you out because you have not used Emergency Alerts for a while"
         )

--- a/tests/functional/preview_and_dev/test_session_timeout.py
+++ b/tests/functional/preview_and_dev/test_session_timeout.py
@@ -87,12 +87,16 @@ def test_dialogs_appears_and_signs_user_out_at_max_session_lifetime(driver):
     assert dashboard_with_dialogs_page.is_expiry_dialog_hidden()
     time.sleep(10)
     sign_in_page = SignInPage(driver)
-    assert sign_in_page.text_is_on_page("You’ve been signed out")
-    assert sign_in_page.text_is_on_page(
-        "We do this every hour to keep your information secure. Sign back in to start a new session"
-    )
-    assert dashboard_with_dialogs_page.url_contains("status=expired")
-    assert dashboard_with_dialogs_page.url_contains("templates")
+    if sign_in_page.text_is_on_page("You’ve been signed out"):
+        assert sign_in_page.text_is_on_page(
+            "We do this every hour to keep your information secure. Sign back in to start a new session"
+        )
+        assert dashboard_with_dialogs_page.url_contains("status=expired")
+        assert dashboard_with_dialogs_page.url_contains("templates")
+    elif sign_in_page.text_is_on_page("You need to sign in again"):
+        assert sign_in_page.text_is_on_page(
+            "We signed you out because you have not used Emergency Alerts for a while"
+        )
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -178,3 +178,7 @@ class RejectionReasonTextArea(BasePageElement):
 
 class RejectAlertButton(BasePageElement):
     name = RejectionFormLocators.REJECT_ALERT_BUTTON[1]
+
+
+class RejectionDetailLink:
+    name = RejectionFormLocators.REJECTION_DETAIL_LINK[1]

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -10,6 +10,7 @@ from tests.pages.locators import (
     EditTemplatePageLocators,
     NewPasswordPageLocators,
     PlatformAdminPageLocators,
+    RejectionFormLocators,
     SearchCoordinatePageLocators,
     SearchPostcodePageLocators,
     SignUpPageLocators,
@@ -165,3 +166,15 @@ class ExpiryDialog(BasePageElement):
 
 class ExpiryDialogContinueButton(BasePageElement):
     name = DashboardWithDialogPageLocators.CONTINUE_BUTTON[1]
+
+
+class RejectionDetailElement(BasePageElement):
+    name = RejectionFormLocators.REJECTION_DETAIL_ELEMENT[1]
+
+
+class RejectionReasonTextArea(BasePageElement):
+    name = RejectionFormLocators.REJECTION_REASON_TEXTAREA[1]
+
+
+class RejectAlertButton(BasePageElement):
+    name = RejectionFormLocators.REJECT_ALERT_BUTTON[1]

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -229,4 +229,4 @@ class RejectionFormLocators(object):
     )
     REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
     REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
-    REJECT_ALERT_BUTTON = (By.CLASS_NAME, ".govuk-button--warning.page-footer__button")
+    REJECT_ALERT_BUTTON = (By.CLASS_NAME, "govuk-button--warning")

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -223,6 +223,10 @@ class DashboardWithDialogPageLocators(object):
 
 
 class RejectionFormLocators(object):
+    REJECTION_DETAIL_LINK = (
+        By.XPATH,
+        '//*[@id="rejection_reason_details"]/summary/span',
+    )
     REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
     REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
     REJECT_ALERT_BUTTON = (By.CLASS_NAME, ".govuk-button--warning.page-footer__button")

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -220,3 +220,9 @@ class DashboardWithDialogPageLocators(object):
         '//*[@id="activity" and @class="hmrc-timeout-dialog"]',
     )
     CONTINUE_BUTTON = (By.NAME, "continue-btn")
+
+
+class RejectionFormLocators(object):
+    REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
+    REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
+    REJECT_ALERT_BUTTON = (By.CLASS_NAME, ".govuk-button--warning.page-footer__button")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -36,6 +36,9 @@ from tests.pages.element import (
     PostcodeInputElement,
     PreviewButton,
     RadiusInputElement,
+    RejectAlertButton,
+    RejectionDetailElement,
+    RejectionReasonTextArea,
     SearchButton,
     SearchInputElement,
     SecondCoordinateInputElement,
@@ -57,6 +60,7 @@ from tests.pages.locators import (
     LetterPreviewPageLocators,
     MainPageLocators,
     NavigationLocators,
+    RejectionFormLocators,
     SearchCoordinatePageLocators,
     SearchPostcodePageLocators,
     ServiceSettingsLocators,
@@ -1484,3 +1488,24 @@ class DashboardWithDialogs(BasePage):
             DashboardWithDialogPageLocators.EXPIRY_DIALOG
         )
         return not element.get_attribute("open")
+
+
+class RejectionForm(BasePage):
+    rejection_detail_element = RejectionDetailElement()
+    rejection_reason_text_area = RejectionReasonTextArea()
+    reject_alert_btn = RejectAlertButton()
+
+    def click_open_reject_detail(self):
+        element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_ELEMENT)
+        element.click()
+
+    def rejection_details_is_open(self):
+        element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_ELEMENT)
+        return element.get_attribute("open")
+
+    def click_reject_alert(self):
+        element = self.wait_for_element(RejectionFormLocators.REJECT_ALERT_BUTTON)
+        element.click()
+
+    def create_rejection_reason_input(self, content):
+        self.rejection_reason_text_area = content

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1505,6 +1505,10 @@ class RejectionForm(BasePage):
         element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_ELEMENT)
         return element.get_attribute("open")
 
+    def rejection_details_is_closed(self):
+        element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_ELEMENT)
+        return not element.get_attribute("open")
+
     def click_reject_alert(self):
         element = self.wait_for_element(RejectionFormLocators.REJECT_ALERT_BUTTON)
         element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1515,3 +1515,8 @@ class RejectionForm(BasePage):
 
     def create_rejection_reason_input(self, content):
         self.rejection_reason_text_area = content
+
+    def get_rejection_form_errors(self):
+        error_message = (By.CSS_SELECTOR, ".govuk-error-message")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -38,6 +38,7 @@ from tests.pages.element import (
     RadiusInputElement,
     RejectAlertButton,
     RejectionDetailElement,
+    RejectionDetailLink,
     RejectionReasonTextArea,
     SearchButton,
     SearchInputElement,
@@ -1494,9 +1495,10 @@ class RejectionForm(BasePage):
     rejection_detail_element = RejectionDetailElement()
     rejection_reason_text_area = RejectionReasonTextArea()
     reject_alert_btn = RejectAlertButton()
+    rejection_detail_link = RejectionDetailLink()
 
     def click_open_reject_detail(self):
-        element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_ELEMENT)
+        element = self.wait_for_element(RejectionFormLocators.REJECTION_DETAIL_LINK)
         element.click()
 
     def rejection_details_is_open(self):


### PR DESCRIPTION
This PR consists of:
- Additional test (to broadcast_flow suite) for reason for rejection work
- Required page, elements & locators for the test
- Adjustment to session_timeout test to ensure assertions are made even when flask session has ended for test user