### PR TITLE
EAS-2569: Tests: Use admin approval process for API key test

### DIFF
--- a/config.py
+++ b/config.py
@@ -120,6 +120,12 @@ def setup_preview_dev_config():
                     "password": os.environ["PLATFORM_ADMIN_PASSWORD"],
                     "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
                 },
+                "platform_admin_2": {
+                    "id": os.environ["PLATFORM_ADMIN_ID"],
+                    "email": os.environ["PLATFORM_ADMIN_EMAIL"],
+                    "password": os.environ["PLATFORM_ADMIN_PASSWORD"],
+                    "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
+                },
                 "throttled_user": {
                     "id": os.environ["THROTTLED_USER_ID"],
                     "email": os.environ["THROTTLED_USER_EMAIL"],

--- a/environment.sh
+++ b/environment.sh
@@ -49,6 +49,11 @@ export PLATFORM_ADMIN_EMAIL='emergency-alerts-tests-admin@digital.cabinet-office
 export PLATFORM_ADMIN_PASSWORD=Password1234
 export PLATFORM_ADMIN_NUMBER=07700900222
 
+export PLATFORM_ADMIN_2_ID='d0347043-45f4-4dc7-a72b-8e2adc72e683'
+export PLATFORM_ADMIN_2_EMAIL='emergency-alerts-tests-admin+2@digital.cabinet-office.gov.uk'
+export PLATFORM_ADMIN_2_PASSWORD=Password1234
+export PLATFORM_ADMIN_2_NUMBER=07700900222
+
 export THROTTLED_USER_ID='7a7d9571-7583-4b69-86c7-256753797dbe'
 export THROTTLED_USER_EMAIL='emergency-alerts-tests+user5@digital.cabinet-office.gov.uk'
 export THROTTLED_USER_PASSWORD=Password1234

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -34,6 +34,7 @@ def preview_dev_config():
     purge_folders_and_templates(test_api_client)
     purge_user_created_services(test_api_client)
     purge_users_created_by_functional_tests(test_api_client)
+    purge_admin_actions_created_by_functional_tests(test_api_client)
     purge_failed_logins_created_by_functional_tests(test_api_client)
     yield
     logging.info(str(time.time()) + " Tearing down preview_dev_config")
@@ -83,6 +84,13 @@ def purge_user_created_services(test_api_client):
 
 def purge_users_created_by_functional_tests(test_api_client):
     url = "/service/purge-users-created-by-tests"
+    test_api_client.delete(url)
+
+
+def purge_admin_actions_created_by_functional_tests(test_api_client):
+    admin_user = config["broadcast_service"]["platform_admin"]["id"]
+
+    url = f"/admin-action/purge/{admin_user}"
     test_api_client.delete(url)
 
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -193,3 +193,8 @@ class RejectionFormLocators(object):
     REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
     REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
     REJECT_ALERT_BUTTON = (By.CLASS_NAME, "govuk-button--warning")
+
+
+class AdminApprovalPageLocators(object):
+    APPROVE_BUTTON = (By.CSS_SELECTOR, "button[data-button-type='approve']")
+    REJECT_BUTTON = (By.CSS_SELECTOR, "button[data-button-type='reject']")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -50,6 +50,7 @@ from tests.pages.element import (
 )
 from tests.pages.locators import (
     AddServicePageLocators,
+    AdminApprovalPageLocators,
     ApiIntegrationPageLocators,
     ApiKeysPageLocators,
     ChangeNameLocators,
@@ -940,21 +941,6 @@ class ApiKeysPage(BasePage):
         self.select_checkbox_or_radio(value="normal")
         self.click_submit()
 
-    def get_key_name(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_VALUE)
-        return element.text
-
-    def wait_for_key_copy_button(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_BUTTON)
-        return element
-
-    def wait_for_show_key_button(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_SHOW_BUTTON)
-        return element
-
-    def check_new_key_name(self, starts_with):
-        return self.get_key_name().startswith(starts_with)
-
     def get_revoke_link_for_api_key(self, key_name):
         return self.wait_for_element(
             (
@@ -1355,3 +1341,25 @@ class RejectionForm(BasePage):
         error_message = (By.CSS_SELECTOR, ".govuk-error-message")
         errors = self.wait_for_element(error_message)
         return errors.text.strip()
+
+
+class AdminApprovalsPage(BasePage):
+    def approve_action(self):
+        approve = self.wait_for_element(AdminApprovalPageLocators.APPROVE_BUTTON)
+        approve.click()
+
+    # Only relevant for approved API key actions:
+    def get_key_name(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_VALUE)
+        return element.text
+
+    def wait_for_key_copy_button(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_BUTTON)
+        return element
+
+    def wait_for_show_key_button(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_SHOW_BUTTON)
+        return element
+
+    def check_new_key_name(self, starts_with):
+        return self.get_key_name().startswith(starts_with)

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -70,7 +70,7 @@ def _sign_in(driver, account_type):
     sign_in_page.login(email, password)
 
 
-def get_email_and_password(account_type):
+def get_email_and_password(account_type):  # noqa: C901
     if account_type == "normal":
         return config["user"]["email"], config["user"]["password"]
     elif account_type == "seeded":
@@ -99,6 +99,11 @@ def get_email_and_password(account_type):
             config["broadcast_service"]["platform_admin"]["email"],
             config["broadcast_service"]["platform_admin"]["password"],
         )
+    elif account_type == "platform_admin_2":
+        return (
+            config["broadcast_service"]["platform_admin_2"]["email"],
+            config["broadcast_service"]["platform_admin_2"]["password"],
+        )
     elif account_type == "session_timeout":
         return (
             config["broadcast_service"]["session_timeout"]["email"],
@@ -107,7 +112,7 @@ def get_email_and_password(account_type):
     raise Exception("unknown account_type {}".format(account_type))
 
 
-def get_identifier(account_type):
+def get_identifier(account_type):  # noqa: C901
     if account_type == "broadcast_approve_user":
         return config["broadcast_service"]["broadcast_user_2"]["id"]
     elif account_type == "broadcast_auth_test_user":
@@ -118,6 +123,8 @@ def get_identifier(account_type):
         return config["user"]["mobile"]
     elif account_type == "platform_admin":
         return config["broadcast_service"]["platform_admin"]["id"]
+    elif account_type == "platform_admin_2":
+        return config["broadcast_service"]["platform_admin_2"]["id"]
     elif account_type == "seeded":
         return config["service"]["seeded_user"]["mobile"]
     elif account_type == "session_timeout":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ ACCOUNTS_REQUIRING_SMS_2FA = [
     "broadcast_create_user",
     "broadcast_approve_user",
     "platform_admin",
+    "platform_admin_2",
 ]
 
 PROVIDERS = ["ee", "o2", "vodafone", "three"]


### PR DESCRIPTION
> Requires https://github.com/alphagov/emergency-alerts-tooling/pull/45 and https://github.com/alphagov/emergency-alerts-api/pull/198

After only 4 days of battling, I now finally have a test running against the new admin approvals system. This is just one test - a tweak to the API key creation, as the existing invite test does not request any permissions which require approval.

I'll try to create tests which do, but given I'm going away and this has taken _an extremely short amount of time_ I thought I'd get a PR up anyway.

Evidence that it did at one time pass(!):
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/77b73098-c7bd-47cb-ba41-6f3b898d1f42" />
