### PR TITLE
EAS-2547 Redirect after password reset

### DIFF
--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -56,6 +56,16 @@ def test_reset_forgotten_password(driver):
     verify_page = VerifyPage(driver)
     verify_page.verify(verify_code)
 
+    password_reset_sign_in_page = SignInPage(driver)
+    assert password_reset_sign_in_page.text_is_on_page(
+        "You've just changed your password. Sign in with your new password."
+    )
+    password_reset_sign_in_page.login(login_email, new_password)
+    verify_code = get_verify_code_from_api_by_id(
+        config["broadcast_service"]["broadcast_user_3"]["id"]
+    )
+    verify_page = VerifyPage(driver)
+    verify_page.verify(verify_code)
     landing_page = BasePage(driver)
     assert landing_page.url_contains("current-alerts")
 

--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -57,6 +57,7 @@ def test_reset_forgotten_password(driver):
     verify_page.verify(verify_code)
 
     password_reset_sign_in_page = SignInPage(driver)
+    # Redirects to sign in page so user must sign in again after verifying password reset
     assert password_reset_sign_in_page.text_is_on_page(
         "You've just changed your password. Sign in with your new password."
     )


### PR DESCRIPTION
This PR adjusts the `test_reset_forgotten_password` test to account for the fact that now after resetting password, users are redirected to sign in page where they have to use updated password to sign in again.

Admin PR for functionality change https://github.com/alphagov/emergency-alerts-admin/pull/229