### PR TITLE
Adjusts method used to submit alert for approval

### DIFF
--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -157,7 +157,7 @@ def create_alert(driver, id):
     assert preview_alert_page.text_is_on_page("England")
     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
-    preview_alert_page.click_submit()
+    preview_alert_page.click_submit_for_approval()
     assert preview_alert_page.text_is_on_page(
         f"{broadcast_title} is waiting for approval"
     )


### PR DESCRIPTION
This PR adjusts the method used to submit the alert for approval - currently the tests use method with incorrect locator and using `click_submit_for_approval` ensures that they click the correct button.