### PR TITLE
EAS-2569: Tests: Admin approval for API key and privileged user creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -120,6 +120,12 @@ def setup_preview_dev_config():
                     "password": os.environ["PLATFORM_ADMIN_PASSWORD"],
                     "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
                 },
+                "platform_admin_2": {
+                    "id": os.environ["PLATFORM_ADMIN_ID"],
+                    "email": os.environ["PLATFORM_ADMIN_EMAIL"],
+                    "password": os.environ["PLATFORM_ADMIN_PASSWORD"],
+                    "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
+                },
                 "throttled_user": {
                     "id": os.environ["THROTTLED_USER_ID"],
                     "email": os.environ["THROTTLED_USER_EMAIL"],

--- a/config.py
+++ b/config.py
@@ -16,8 +16,8 @@ config = {
     "verify_code_retry_interval": 1,
     "govuk_alerts_wait_retry_times": 20,
     "govuk_alerts_wait_retry_interval": 5,
-    "ui_element_retry_times": 5,
-    "ui_element_retry_interval": 1,
+    "ui_element_retry_times": 3,
+    "ui_element_retry_interval": 0.5,
     "dynamo_query_retry_times": 20,
     "dynamo_query_retry_interval": 5,
     "notify_templates": {

--- a/environment.sh
+++ b/environment.sh
@@ -49,6 +49,11 @@ export PLATFORM_ADMIN_EMAIL='emergency-alerts-tests-admin@digital.cabinet-office
 export PLATFORM_ADMIN_PASSWORD=Password1234
 export PLATFORM_ADMIN_NUMBER=07700900222
 
+export PLATFORM_ADMIN_2_ID='d0347043-45f4-4dc7-a72b-8e2adc72e683'
+export PLATFORM_ADMIN_2_EMAIL='emergency-alerts-tests-admin+2@digital.cabinet-office.gov.uk'
+export PLATFORM_ADMIN_2_PASSWORD=Password1234
+export PLATFORM_ADMIN_2_NUMBER=07700900222
+
 export THROTTLED_USER_ID='7a7d9571-7583-4b69-86c7-256753797dbe'
 export THROTTLED_USER_EMAIL='emergency-alerts-tests+user5@digital.cabinet-office.gov.uk'
 export THROTTLED_USER_PASSWORD=Password1234

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -97,3 +97,9 @@ def purge_admin_actions_created_by_functional_tests(test_api_client):
 def purge_failed_logins_created_by_functional_tests(test_api_client):
     url = "/service/purge-failed-logins-created-by-tests"
     test_api_client.delete(url)
+
+
+# A fixture that can be called ad-hoc in tests known to trigger throttling
+@pytest.fixture
+def purge_failed_logins():
+    return lambda: purge_failed_logins_created_by_functional_tests(create_test_client())

--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -34,6 +34,7 @@ def preview_dev_config():
     purge_folders_and_templates(test_api_client)
     purge_user_created_services(test_api_client)
     purge_users_created_by_functional_tests(test_api_client)
+    purge_admin_actions_created_by_functional_tests(test_api_client)
     purge_failed_logins_created_by_functional_tests(test_api_client)
     yield
     logging.info(str(time.time()) + " Tearing down preview_dev_config")
@@ -83,6 +84,13 @@ def purge_user_created_services(test_api_client):
 
 def purge_users_created_by_functional_tests(test_api_client):
     url = "/service/purge-users-created-by-tests"
+    test_api_client.delete(url)
+
+
+def purge_admin_actions_created_by_functional_tests(test_api_client):
+    admin_user = config["broadcast_service"]["platform_admin"]["id"]
+
+    url = f"/admin-action/purge/{admin_user}"
     test_api_client.delete(url)
 
 

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -103,6 +103,7 @@ def test_platform_admin_can_invite_new_user_and_delete_user(
         admin_approvals_page = AdminApprovalsPage(driver)
         admin_approvals_page.get(relative_url="/platform-admin/admin-actions")
         admin_approvals_page.approve_action()
+        time.sleep(1)
 
         assert invite_user_page.text_is_on_page(
             "Sent invite to user " + invited_user_email
@@ -176,7 +177,6 @@ def test_platform_admin_can_invite_new_user_and_delete_user(
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_service_admin_search_for_user_by_name_and_email(driver):
-    time.sleep(20)
     sign_in(driver, account_type="platform_admin")
 
     current_alerts_page = CurrentAlertsPage(driver)

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -58,9 +58,18 @@ def test_add_rename_and_delete_service(driver):
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_service_admin_can_invite_new_user_and_delete_user(driver, api_client):
+@pytest.mark.parametrize(
+    "user_requires_admin_approval",
+    ((True), (False)),
+)
+def test_platform_admin_can_invite_new_user_and_delete_user(
+    driver, api_client, purge_failed_logins, user_requires_admin_approval
+):
+    """
+    This refers to the unprivileged user flow - i.e. a user without a permission that would
+    require approval from another admin.
+    """
     timestamp = str(int(time.time()))
-    time.sleep(30)  # To avoid throttle
 
     sign_in(driver, account_type="platform_admin")
 
@@ -75,12 +84,35 @@ def test_service_admin_can_invite_new_user_and_delete_user(driver, api_client):
         f"emergency-alerts-tests+fake-{timestamp}@digital.cabinet-office.gov.uk"
     )
     invite_user_page = InviteUserPage(driver)
-    invite_user_page.send_invitation_without_permissions(invited_user_email)
+    if user_requires_admin_approval:
+        invite_user_page.check_create_broadcasts_checkbox()
+    invite_user_page.send_invitation_to_email(invited_user_email)
+    # There is no wait condition as all pages have an H1 - so wait for the browser to have done loading
+    time.sleep(1)
     assert invite_user_page.is_page_title("Team members")
-    assert invite_user_page.text_is_on_page("Invite sent to " + invited_user_email)
+
+    if user_requires_admin_approval:
+        assert invite_user_page.text_is_on_page("An admin approval has been created")
+
+        # Login again as a different platform admin to approve
+        invite_user_page.sign_out()
+        purge_failed_logins()  # To avoid throttle - email lookups trigger throttle logic
+        sign_in(driver, account_type="platform_admin_2")
+
+        # Approve/create it
+        admin_approvals_page = AdminApprovalsPage(driver)
+        admin_approvals_page.get(relative_url="/platform-admin/admin-actions")
+        admin_approvals_page.approve_action()
+
+        assert invite_user_page.text_is_on_page(
+            "Sent invite to user " + invited_user_email
+        )
+
+    else:
+        assert invite_user_page.text_is_on_page("Invite sent to " + invited_user_email)
 
     invite_user_page.sign_out()
-    time.sleep(30)  # To avoid throttle
+    purge_failed_logins()  # To avoid throttle - email lookups trigger throttle logic
 
     # get user's invitation id from db using their email
     response = api_client.post(url="/user/invited", data={"email": invited_user_email})
@@ -93,13 +125,13 @@ def test_service_admin_can_invite_new_user_and_delete_user(driver, api_client):
     home_page.get(invitation_url)
     home_page.accept_cookie_warning()
 
-    time.sleep(30)  # To avoid throttle
+    purge_failed_logins()  # To avoid throttle - email lookups trigger throttle logic
 
     registration_page = RegisterFromInvite(driver)
     assert registration_page.is_page_title("Create an account")
     registration_page.fill_registration_form(name="User " + timestamp)
     registration_page.click_continue_to_signin()
-    time.sleep(30)
+    time.sleep(1)
     # get user_id of invited user by their email
     response = api_client.post(url="/user/email", data={"email": invited_user_email})
     user_id = response["data"]["id"]

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -49,7 +49,7 @@ def test_add_rename_and_delete_service(driver):
     assert service_settings_page.get_service_name() == f"{new_service_name} TRAINING"
 
     service_settings_page.delete_service()
-    time.sleep(10)
+    time.sleep(1)
     assert service_settings_page.text_is_on_page(f"‘{new_service_name}’ was deleted")
 
     # sign out

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -93,6 +93,10 @@ class TeamMembersPageLocators(object):
 
 
 class InviteUserPageLocators(object):
+    CREATE_BROADCASTS_CHECKBOX = (
+        By.CSS_SELECTOR,
+        "[value=create_broadcasts], [name=create_broadcasts]",
+    )
     SEND_MESSAGES_CHECKBOX = (
         By.CSS_SELECTOR,
         "[value=send_messages], [name=send_messages]",

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -193,3 +193,8 @@ class RejectionFormLocators(object):
     REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
     REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
     REJECT_ALERT_BUTTON = (By.CLASS_NAME, "govuk-button--warning")
+
+
+class AdminApprovalPageLocators(object):
+    APPROVE_BUTTON = (By.CSS_SELECTOR, "button[data-button-type='approve']")
+    REJECT_BUTTON = (By.CSS_SELECTOR, "button[data-button-type='reject']")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -50,6 +50,7 @@ from tests.pages.element import (
 )
 from tests.pages.locators import (
     AddServicePageLocators,
+    AdminApprovalPageLocators,
     ApiIntegrationPageLocators,
     ApiKeysPageLocators,
     ChangeNameLocators,
@@ -940,21 +941,6 @@ class ApiKeysPage(BasePage):
         self.select_checkbox_or_radio(value="normal")
         self.click_submit()
 
-    def get_key_name(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_VALUE)
-        return element.text
-
-    def wait_for_key_copy_button(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_BUTTON)
-        return element
-
-    def wait_for_show_key_button(self):
-        element = self.wait_for_element(ApiKeysPageLocators.KEY_SHOW_BUTTON)
-        return element
-
-    def check_new_key_name(self, starts_with):
-        return self.get_key_name().startswith(starts_with)
-
     def get_revoke_link_for_api_key(self, key_name):
         return self.wait_for_element(
             (
@@ -1355,3 +1341,25 @@ class RejectionForm(BasePage):
         error_message = (By.CSS_SELECTOR, ".govuk-error-message")
         errors = self.wait_for_element(error_message)
         return errors.text.strip()
+
+
+class AdminApprovalsPage(BasePage):
+    def approve_action(self):
+        approve = self.wait_for_element(AdminApprovalPageLocators.APPROVE_BUTTON)
+        approve.click()
+
+    # Only relevant for approved API key actions:
+    def get_key_name(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_VALUE)
+        return element.text
+
+    def wait_for_key_copy_button(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_COPY_BUTTON)
+        return element
+
+    def wait_for_show_key_button(self):
+        element = self.wait_for_element(ApiKeysPageLocators.KEY_SHOW_BUTTON)
+        return element
+
+    def check_new_key_name(self, starts_with):
+        return self.get_key_name().startswith(starts_with)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -263,8 +263,17 @@ class BasePage(object):
         element.click()
 
     def is_page_title(self, expected_page_title):
-        element = self.wait_for_element(CommonPageLocators.H1)
-        return element.text == expected_page_title
+        # The H1 is on all pages but sometimes returns the last page's value so it's just retried here
+        tries = config["ui_element_retry_times"]
+        retry_interval = config["ui_element_retry_interval"]
+        while tries > 0:
+            element = self.wait_for_element(CommonPageLocators.H1)
+            if element.text == expected_page_title:
+                return True
+            tries -= 1
+            sleep(retry_interval)
+
+        return False
 
     @retry(
         RetryException,

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -191,7 +191,7 @@ class BasePage(object):
         self.driver.delete_all_cookies()
 
     def sign_out_if_required(self):
-        if self.text_is_on_page("Sign out"):
+        if self.text_is_on_page_no_wait("Sign out"):
             self.sign_out()
         self.driver.delete_all_cookies()
 
@@ -278,12 +278,16 @@ class BasePage(object):
             raise RetryException(f'Could not find text "{search_text}"')
         return True
 
+    def text_is_on_page_no_wait(self, search_text):
+        normalized_page_source = " ".join(self.driver.page_source.split())
+        if search_text in normalized_page_source:
+            return True
+
     def text_is_on_page(self, search_text):
         tries = config["ui_element_retry_times"]
         retry_interval = config["ui_element_retry_interval"]
         while tries > 0:
-            normalized_page_source = " ".join(self.driver.page_source.split())
-            if search_text in normalized_page_source:
+            if self.text_is_on_page_no_wait(search_text):
                 return True
             tries -= 1
             sleep(retry_interval)

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -794,6 +794,7 @@ class InviteUserPage(BasePage):
     see_dashboard_check_box = InviteUserPageLocators.SEE_DASHBOARD_CHECKBOX
     choose_folders_button = InviteUserPageLocators.CHOOSE_FOLDERS_BUTTON
     send_messages_checkbox = InviteUserPageLocators.SEND_MESSAGES_CHECKBOX
+    create_broadcasts_checkbox = InviteUserPageLocators.CREATE_BROADCASTS_CHECKBOX
     manage_services_checkbox = InviteUserPageLocators.MANAGE_SERVICES_CHECKBOX
     manage_templates_checkbox = InviteUserPageLocators.MANAGE_TEMPLATES_CHECKBOX
     manage_api_keys_checkbox = InviteUserPageLocators.MANAGE_API_KEYS_CHECKBOX
@@ -839,7 +840,13 @@ class InviteUserPage(BasePage):
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()
 
-    def send_invitation_without_permissions(self, email):
+    def check_create_broadcasts_checkbox(self):
+        element = self.wait_for_invisible_element(
+            InviteUserPage.create_broadcasts_checkbox
+        )
+        self.select_checkbox_or_radio(element)
+
+    def send_invitation_to_email(self, email):
         self.email_input = email
         element = self.wait_for_element(InviteUserPage.send_invitation_button)
         element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -283,7 +283,6 @@ class BasePage(object):
     def text_is_on_page_with_exception(self, search_text):
         normalized_page_source = " ".join(self.driver.page_source.split())
         if search_text not in normalized_page_source:
-            self.driver.refresh()
             raise RetryException(f'Could not find text "{search_text}"')
         return True
 
@@ -300,7 +299,6 @@ class BasePage(object):
                 return True
             tries -= 1
             sleep(retry_interval)
-            self.driver.refresh()
         return False
 
     def text_is_not_on_page(self, search_text):
@@ -312,7 +310,6 @@ class BasePage(object):
                 return False
             tries -= 1
             sleep(retry_interval)
-            self.driver.refresh()
         return True
 
     def get_template_id(self):
@@ -1204,7 +1201,6 @@ class GovUkAlertsPage(BasePage):
     )
     def check_alert_is_published(self, broadcast_content):
         if not self.text_is_on_page(broadcast_content):
-            self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
             )

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -26,10 +26,8 @@ def sign_in(driver, account_type="normal"):
     home_page.accept_cookie_warning()
 
     _sign_in(driver, account_type)
+    time.sleep(1)  # Wait for the code in the DB to not be in the same second
     identifier = get_identifier(account_type=account_type)
-    # wait before requesting verification code - this pause may not
-    # be necessary when the aggressive throttling issue is fixed
-    time.sleep(10)
     if account_type in ACCOUNTS_REQUIRING_SMS_2FA:
         do_verify_by_id(driver, identifier)
     else:

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -51,7 +51,7 @@ def get_verify_code(account_identifier):
 
 def clean_session(driver):
     page = BasePage(driver)
-    if page.text_is_on_page("Sign out"):
+    if page.text_is_on_page_no_wait("Sign out"):
         page.sign_out()
     driver.delete_all_cookies()
 

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -70,7 +70,7 @@ def _sign_in(driver, account_type):
     sign_in_page.login(email, password)
 
 
-def get_email_and_password(account_type):
+def get_email_and_password(account_type):  # noqa: C901
     if account_type == "normal":
         return config["user"]["email"], config["user"]["password"]
     elif account_type == "seeded":
@@ -99,6 +99,11 @@ def get_email_and_password(account_type):
             config["broadcast_service"]["platform_admin"]["email"],
             config["broadcast_service"]["platform_admin"]["password"],
         )
+    elif account_type == "platform_admin_2":
+        return (
+            config["broadcast_service"]["platform_admin_2"]["email"],
+            config["broadcast_service"]["platform_admin_2"]["password"],
+        )
     elif account_type == "session_timeout":
         return (
             config["broadcast_service"]["session_timeout"]["email"],
@@ -107,7 +112,7 @@ def get_email_and_password(account_type):
     raise Exception("unknown account_type {}".format(account_type))
 
 
-def get_identifier(account_type):
+def get_identifier(account_type):  # noqa: C901
     if account_type == "broadcast_approve_user":
         return config["broadcast_service"]["broadcast_user_2"]["id"]
     elif account_type == "broadcast_auth_test_user":
@@ -118,6 +123,8 @@ def get_identifier(account_type):
         return config["user"]["mobile"]
     elif account_type == "platform_admin":
         return config["broadcast_service"]["platform_admin"]["id"]
+    elif account_type == "platform_admin_2":
+        return config["broadcast_service"]["platform_admin_2"]["id"]
     elif account_type == "seeded":
         return config["service"]["seeded_user"]["mobile"]
     elif account_type == "session_timeout":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ ACCOUNTS_REQUIRING_SMS_2FA = [
     "broadcast_create_user",
     "broadcast_approve_user",
     "platform_admin",
+    "platform_admin_2",
 ]
 
 PROVIDERS = ["ee", "o2", "vodafone", "three"]


### PR DESCRIPTION
> This supersedes #127

As title, there's an expansion to the tests:
- The API key test now goes through the admin approval process with the new additional platform admin
- There's an extra test that goes through the admin approval loop when inviting a user with a privileged permission (create)

In addition to the core test tweaks, I've spent a long time observing the tests locally and I realise a lot of time was spent waiting and refreshing pages. To this end I've tried to remove as much sleeping as we can but it's not perfect - though a run in AWS now goes from around 50 minutes to 15ish! 🎉  I believe throttling was the biggest concern but the fixtures should clean this up, and for the platform admin tests I've made it so we can just reset it on the fly.

There is still some degree of waiting and retrying, such as `is_page_title` for some reason returning immediately but with possibly the previous page's results so I just do a small retry loop without a page refresh. (This probably means I don't understand Selenium's lifecycle, like does it wait for navigation to finish before proceeding?)