### PR TITLE
Reinstate page refreshing

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ config = {
 }
 
 tenant = f"{os.environ.get('TENANT')}."
-govuk_alerts_url = os.environ.get("GOVUK_ALERTS_URL").removeprefix("https://")
+govuk_alerts_url = os.environ.get("GOVUK_ALERTS_URL", "").removeprefix("https://")
 urls = {
     "local": {
         "api": "http://localhost:6011",
@@ -121,10 +121,10 @@ def setup_preview_dev_config():
                     "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
                 },
                 "platform_admin_2": {
-                    "id": os.environ["PLATFORM_ADMIN_ID"],
-                    "email": os.environ["PLATFORM_ADMIN_EMAIL"],
-                    "password": os.environ["PLATFORM_ADMIN_PASSWORD"],
-                    "mobile": os.environ["PLATFORM_ADMIN_NUMBER"],
+                    "id": os.environ["PLATFORM_ADMIN_2_ID"],
+                    "email": os.environ["PLATFORM_ADMIN_2_EMAIL"],
+                    "password": os.environ["PLATFORM_ADMIN_2_PASSWORD"],
+                    "mobile": os.environ["PLATFORM_ADMIN_2_NUMBER"],
                 },
                 "throttled_user": {
                     "id": os.environ["THROTTLED_USER_ID"],

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -283,6 +283,7 @@ class BasePage(object):
     def text_is_on_page_with_exception(self, search_text):
         normalized_page_source = " ".join(self.driver.page_source.split())
         if search_text not in normalized_page_source:
+            self.driver.refresh()
             raise RetryException(f'Could not find text "{search_text}"')
         return True
 
@@ -299,6 +300,7 @@ class BasePage(object):
                 return True
             tries -= 1
             sleep(retry_interval)
+            self.driver.refresh()
         return False
 
     def text_is_not_on_page(self, search_text):
@@ -310,6 +312,7 @@ class BasePage(object):
                 return False
             tries -= 1
             sleep(retry_interval)
+            self.driver.refresh()
         return True
 
     def get_template_id(self):
@@ -1201,6 +1204,7 @@ class GovUkAlertsPage(BasePage):
     )
     def check_alert_is_published(self, broadcast_content):
         if not self.text_is_on_page(broadcast_content):
+            self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
             )


### PR DESCRIPTION
It seems this breaks in non-development environments. I'm assuming something around alerts is asynchronous but it's to observe what goes on in the depths of CodeBuild.

More interestingly the config for the secondary platform admin should now actually consult the secondary values. What I can't make sense of is how this worked at all in my development environment in that state!