### PR TITLE
Adjusting text on sign-in page

### DIFF
--- a/tests/functional/preview_and_dev/test_session_timeout.py
+++ b/tests/functional/preview_and_dev/test_session_timeout.py
@@ -89,7 +89,7 @@ def test_dialogs_appears_and_signs_user_out_at_max_session_lifetime(driver):
     sign_in_page = SignInPage(driver)
     if sign_in_page.text_is_on_page("You’ve been signed out"):
         assert sign_in_page.text_is_on_page(
-            "We do this every hour to keep your information secure. Sign back in to start a new session"
+            "We do this every 6 hours to keep your information secure. Sign back in to start a new session"
         )
         assert dashboard_with_dialogs_page.url_contains("status=expired")
         assert dashboard_with_dialogs_page.url_contains("templates")


### PR DESCRIPTION
This PR includes the adjustment of the text on the sign in page from "every hour" to "every 6 hours", to reflect the increase in session lifetime, as introduced in Admin PR https://github.com/alphagov/emergency-alerts-admin/pull/230