### PR TITLE
EAS-2173: Functional Tests: Use admin elevation process in platform admin tests

### DIFF
--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import pytest
+from notifications_python_client.errors import HTTPError
 
 from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
@@ -34,7 +35,13 @@ def preview_dev_config():
     purge_folders_and_templates(test_api_client)
     purge_user_created_services(test_api_client)
     purge_users_created_by_functional_tests(test_api_client)
-    purge_admin_actions_created_by_functional_tests(test_api_client)
+    platform_admin_ids = [
+        config["broadcast_service"]["platform_admin"]["id"],
+        config["broadcast_service"]["platform_admin_2"]["id"],
+    ]
+    for user_id in platform_admin_ids:
+        purge_admin_actions_created_by_functional_tests(test_api_client, user_id)
+        reset_platform_admin_redemption(test_api_client, user_id)
     purge_failed_logins_created_by_functional_tests(test_api_client)
     yield
     logging.info(str(time.time()) + " Tearing down preview_dev_config")
@@ -87,16 +94,22 @@ def purge_users_created_by_functional_tests(test_api_client):
     test_api_client.delete(url)
 
 
-def purge_admin_actions_created_by_functional_tests(test_api_client):
-    admin_user = config["broadcast_service"]["platform_admin"]["id"]
-
-    url = f"/admin-action/purge/{admin_user}"
+def purge_admin_actions_created_by_functional_tests(test_api_client, user_id):
+    url = f"/admin-action/purge/{user_id}"
     test_api_client.delete(url)
 
 
 def purge_failed_logins_created_by_functional_tests(test_api_client):
     url = "/service/purge-failed-logins-created-by-tests"
     test_api_client.delete(url)
+
+
+def reset_platform_admin_redemption(test_api_client, user_id):
+    url = f"/user/{user_id}/redeem-elevation"
+    try:
+        test_api_client.post(url, data={})
+    except HTTPError:
+        pass  # May return an error if there's no redemption, but that's ok
 
 
 # A fixture that can be called ad-hoc in tests known to trigger throttling

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -53,8 +53,6 @@ def test_add_rename_and_delete_service(driver, purge_failed_logins):
         f"‘{new_service_name}’ was deleted"
     )
 
-    # sign out
-    service_settings_page.get()
     service_settings_page.sign_out()
 
 

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -57,11 +57,11 @@ def test_add_rename_and_delete_training_service(driver, purge_failed_logins):
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_add_modify_and_delete_live_service(driver):
+def test_add_modify_and_delete_live_service(driver, purge_failed_logins):
     timestamp = str(int(time.time()))
     service_name = f"Functional Test {timestamp}"
 
-    sign_in(driver, account_type="platform_admin")
+    sign_in_elevated_platform_admin(driver, purge_failed_logins)
 
     landing_page = BasePage(driver)
 
@@ -108,7 +108,6 @@ def test_add_modify_and_delete_live_service(driver):
     )
 
     service_settings_page.delete_service()
-    time.sleep(1)
     assert service_settings_page.text_is_on_page(f"‘{service_name}’ was deleted")
 
     # sign out

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -1,5 +1,4 @@
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 from tests.pages.locators import (
@@ -52,7 +51,7 @@ class ClearableInputElement(BasePageElement):
             lambda driver: driver.find_element(By.NAME, self.name)
         )
         input = driver.find_element(By.NAME, self.name)
-        input.send_keys(Keys.CONTROL + "a")
+        input.clear()
         input.send_keys(value)
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from time import sleep
 
 from retry import retry
@@ -70,6 +71,22 @@ from tests.pages.locators import (
     VerifyPageLocators,
     ViewTemplatePageLocators,
 )
+
+
+@contextmanager
+def wait_for_page_load_completion(driver):
+    """
+    A helper (to be used in a with statement) that ensures a navigation event has completed before returning to
+    the caller. Useful if a button press causes a navigation event to a page with new content without needing sleep().
+    """
+    old_page = driver.find_element(by=By.TAG_NAME, value="html")
+    yield
+
+    def page_has_loaded(*args):
+        new_page = driver.find_element(by=By.TAG_NAME, value="html")
+        return new_page.id != old_page.id
+
+    WebDriverWait(driver, 10).until(page_has_loaded)
 
 
 class RetryException(Exception):
@@ -303,6 +320,9 @@ class BasePage(object):
             self.driver.refresh()
         return False
 
+    def text_is_not_on_page_no_wait(self, search_text):
+        return not self.text_is_on_page_no_wait(search_text)
+
     def text_is_not_on_page(self, search_text):
         tries = config["ui_element_retry_times"]
         retry_interval = config["ui_element_retry_interval"]
@@ -480,18 +500,20 @@ class SignInPage(BasePage):
         element.click()
 
     def login(self, email, password):
-        self.fill_login_form(email, password)
-        self.click_continue()
+        with wait_for_page_load_completion(self.driver):
+            self.fill_login_form(email, password)
+            self.click_continue()
 
 
 class VerifyPage(BasePage):
     sms_input = SmsInputElement()
 
     def verify(self, code):
-        element = self.wait_for_element(VerifyPageLocators.SMS_INPUT)
-        element.clear()
-        self.sms_input = code
-        self.click_submit()
+        with wait_for_page_load_completion(self.driver):
+            element = self.wait_for_element(VerifyPageLocators.SMS_INPUT)
+            element.clear()
+            self.sms_input = code
+            self.click_submit()
 
 
 class CurrentAlertsPage(BasePage):
@@ -860,9 +882,10 @@ class InviteUserPage(BasePage):
         self.select_checkbox_or_radio(element)
 
     def send_invitation_to_email(self, email):
-        self.email_input = email
-        element = self.wait_for_element(InviteUserPage.send_invitation_button)
-        element.click()
+        with wait_for_page_load_completion(self.driver):
+            self.email_input = email
+            element = self.wait_for_element(InviteUserPage.send_invitation_button)
+            element.click()
 
     # support variants of this page with a 'Save' button instead of 'Send invitation' (both use the same locator)
     def click_save(self):
@@ -996,13 +1019,17 @@ class ServiceSettingsPage(BasePage):
         return element.text
 
     def save_service_name(self, new_name):
-        self.name_input = new_name
-        self.click_save()
+        with wait_for_page_load_completion(self.driver):
+            self.name_input = new_name
+            self.click_save()
 
     def delete_service(self):
-        self.click_element_by_link_text("Delete this service")
-        element = self.wait_for_element(ServiceSettingsLocators.DELETE_CONFIRM_BUTTON)
-        element.click()
+        with wait_for_page_load_completion(self.driver):
+            self.click_element_by_link_text("Delete this service")
+            element = self.wait_for_element(
+                ServiceSettingsLocators.DELETE_CONFIRM_BUTTON
+            )
+            element.click()
 
 
 class ProfileSettingsPage(BasePage):
@@ -1249,12 +1276,18 @@ class PlatformAdminPage(BasePage):
     search_link = (By.LINK_TEXT, "Search")
     search_input = SearchInputElement()
 
+    request_elevation_link = (By.LINK_TEXT, "Request elevation")
+
     def subheading_is(self, expected_subheading):
         element = self.wait_for_element(CommonPageLocators.H2)
         return element.text == expected_subheading
 
     def click_search_link(self):
         element = self.wait_for_element(PlatformAdminPage.search_link)
+        element.click()
+
+    def click_request_elevation_link(self):
+        element = self.wait_for_element(PlatformAdminPage.request_elevation_link)
         element.click()
 
     def search_for(self, text):
@@ -1364,8 +1397,11 @@ class RejectionForm(BasePage):
 
 class AdminApprovalsPage(BasePage):
     def approve_action(self):
-        approve = self.wait_for_element(AdminApprovalPageLocators.APPROVE_BUTTON)
-        approve.click()
+        # Actions can vary on where they direct to after approving, so just wait for the page to finish navigating
+        # somewhere before letting the test continue. This avoids having to sleep arbitrarily.
+        with wait_for_page_load_completion(self.driver):
+            approve = self.wait_for_element(AdminApprovalPageLocators.APPROVE_BUTTON)
+            approve.click()
 
     # Only relevant for approved API key actions:
     def get_key_name(self):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1024,8 +1024,10 @@ class ServiceSettingsPage(BasePage):
             self.click_save()
 
     def delete_service(self):
+        # There's two navigations here, so we need to ensure we don't return after only the first one
         with wait_for_page_load_completion(self.driver):
             self.click_element_by_link_text("Delete this service")
+        with wait_for_page_load_completion(self.driver):
             element = self.wait_for_element(
                 ServiceSettingsLocators.DELETE_CONFIRM_BUTTON
             )

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -82,11 +82,12 @@ def sign_in_elevated_platform_admin(
     purge_failed_logins()  # To avoid throttle
     sign_in(driver, account_type=account_type)
 
-    assert admin_approvals_page.text_is_on_page(
+    assert admin_approvals_page.text_is_on_page_no_wait(
         "approved to temporarily become a platform admin"
     )
-    admin_approvals_page.click_continue()
-    assert admin_approvals_page.text_is_on_page("elevated")
+    with wait_for_page_load_completion(driver):
+        admin_approvals_page.click_continue()
+    assert admin_approvals_page.text_is_on_page_no_wait("elevated")
 
     # This will take the browser to the platform admin page, but let's end up like a sign_in()
     admin_approvals_page.get(relative_url="accounts-or-dashboard")


### PR DESCRIPTION
As title, the platform admin flow tests now hook into the admin elevation process. This is provided by a new rollup helper, `sign_in_elevated_platform_admin`, which goes through as two admins to get the elevated status approved.

Now because this adds two extra login steps for every test that wants elevation (and for the invite user one we need to do it twice!) this will add a bit of a time penalty. To that end I explored where we could speed things up, especially around the sleeps within the normal login process:
- There's a new context manager helper: `wait_for_page_load_completion`, which will get the random Selenium HTML page ID on entry, and will only return once this ID changes (thus indicating the navigation is complete).
  - I've sprinkled this into page methods where we expect a navigation event (e.g. submitting) so that we only start asserting for things after the new page has loaded.
  - This should mean the `text_is_on_page_no_wait` methods should now be reasonably reliable to use, meaning we no longer need arbitrary sleeps or refreshses in the login process. This had a few where it was looking for different bits of text to determine where it ended up.