### PR TITLE
Hotfix: Pin pip to 25.0 as 25.1 can't install successfully

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -34,7 +34,7 @@ phases:
       - unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
       # upgrade pip
-      - pip install --upgrade pip
+      - pip install --upgrade pip==25.0.1
 
       - apt-get install -f -y
 

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -46,7 +46,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip wheel setuptools
+      - python3.9 -m pip install --upgrade pip wheel setuptools==79
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -43,7 +43,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools==79
+      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -33,9 +33,6 @@ phases:
       - wget -O /tmp/chromedriver.zip `cat /tmp/chromedriver_url`
       - unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
-      # upgrade pip
-      - pip install --upgrade pip
-
       - apt-get install -f -y
 
   pre_build:
@@ -46,7 +43,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip wheel setuptools==79
+      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools==79
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -34,7 +34,7 @@ phases:
       - unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
       # upgrade pip
-      - pip install --upgrade pip==25.0.1
+      - pip install --upgrade pip
 
       - apt-get install -f -y
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4>=4.5.1
+beautifulsoup4==4.13.4
 boto3>=1.28.0
 black==24.3.0
 Flask>=0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.13.4
+beautifulsoup4>=4.5.1
 boto3>=1.28.0
 black==24.3.0
 Flask>=0.11.1


### PR DESCRIPTION
This is a temporary hotfix.

The scripts here seem to just grab the latest versions of things, and a recent pip 25.1 release seems to have broken dependency resolution. I haven't been able to really pinpoint the underlying cause (really I should go and get up a virtual environment with logging on) but the symptom is pip going down in the versions of beautifulsoup before reaching our specified one and erroring over `use_2to3`, which was removed a long long time ago in setuptools and probably isn't relevant to the issue at hand.

![image](https://github.com/user-attachments/assets/f858502f-860e-4e96-b14a-9d2ff8772463)
