### PR TITLE
EAS-2418 Return for Edit

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -43,7 +43,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip==25.1.1 wheel setuptools
+      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -43,7 +43,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools
+      - python3.9 -m pip install --upgrade pip wheel setuptools
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -43,7 +43,7 @@ phases:
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip wheel setuptools
+      - python3.9 -m pip install --upgrade pip==25.1.1 wheel setuptools
       - make bootstrap
 
   build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -52,19 +45,6 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          make test-cbc-integration; exit 0
-        else
-          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
-        fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,13 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
+      session-timeout
 
 phases:
   install:
@@ -45,6 +52,19 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          make test-cbc-integration; exit 0
+        else
+          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
+        fi
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.5.1
-boto3>=1.28.0
+boto3==1.28.0
 black==24.3.0
 Flask>=0.11.1
 Flask-Cache==0.13.1

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,7 +1,7 @@
+import logging
 import time
 import uuid
 from datetime import datetime, timedelta
-from venv import logger
 
 import pytest
 
@@ -631,7 +631,7 @@ def test_return_alert_for_edit(driver):
         reason_for_returning_alert
     )
     alert_page_with_return_for_edit.click_return_alert_for_edit()
-    logger.error(alert_page_with_return_for_edit.get_returned_banner_text())
+    logging.error(alert_page_with_return_for_edit.get_returned_banner_text())
     assert (
         alert_page_with_return_for_edit.get_returned_banner_text()
         == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -632,7 +632,7 @@ def test_return_alert_for_edit(driver):
     alert_page_with_return_for_edit.click_return_for_edit_alert()
     assert (
         alert_page_with_return_for_edit.get_returned_banner_text()
-        == f"Reason for being returned for edit: {reason_for_returning_alert}"
+        == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"
     )
     assert alert_page_with_return_for_edit.text_is_on_page(
         "Submitted by Functional Tests - Broadcast User Create"

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -20,6 +20,7 @@ from tests.pages.pages import (
     ChooseCoordinateArea,
     ChooseCoordinatesType,
     RejectionForm,
+    ReturnAlertForEditForm,
     SearchPostcodePage,
 )
 from tests.pages.rollups import sign_in
@@ -551,3 +552,94 @@ def test_reject_alert_with_reason(driver):
     rejected_alerts_page = BasePage(driver)
     assert rejected_alerts_page.text_is_on_page(broadcast_title)
     assert rejected_alerts_page.text_is_on_page(rejection_reason)
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_return_alert_for_edit(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast {test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # Return the alert for edit
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
+    alert_page_with_return_for_edit.click_open_return_for_edit_detail()
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
+
+    # Without rejection reason
+    reason_for_returning_alert = ""
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_for_edit_alert()
+
+    # Assert errors appear
+    assert (
+        alert_page_with_return_for_edit.get_return_for_edit_form_errors()
+        == "Error:\nEnter the reason for returning the alert for edit"
+    )
+
+    # With reason for returning alert for edit
+    reason_for_returning_alert = (
+        "This is a test reason for returning the alert for edit."
+    )
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_for_edit_alert()
+    assert (
+        alert_page_with_return_for_edit.get_returned_banner_text()
+        == f"Reason for being returned for edit: {reason_for_returning_alert}"
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Submitted by Functional Tests - Broadcast User Create"
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Returned by Functional Tests - Broadcast User Approve"
+    )
+
+    assert current_alerts_page.text_is_on_page("Current alerts")
+    assert current_alerts_page.text_is_on_page(broadcast_title)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 from datetime import datetime, timedelta
+from venv import logger
 
 import pytest
 
@@ -630,6 +631,7 @@ def test_return_alert_for_edit(driver):
         reason_for_returning_alert
     )
     alert_page_with_return_for_edit.click_return_alert_for_edit()
+    logger.error(alert_page_with_return_for_edit.get_returned_banner_text())
     assert (
         alert_page_with_return_for_edit.get_returned_banner_text()
         == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,4 +1,3 @@
-import logging
 import time
 import uuid
 from datetime import datetime, timedelta
@@ -631,7 +630,6 @@ def test_return_alert_for_edit(driver):
         reason_for_returning_alert
     )
     alert_page_with_return_for_edit.click_return_alert_for_edit()
-    logging.error(alert_page_with_return_for_edit.get_returned_banner_text())
     assert (
         alert_page_with_return_for_edit.get_returned_banner_text()
         == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -614,7 +614,7 @@ def test_return_alert_for_edit(driver):
     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
         reason_for_returning_alert
     )
-    alert_page_with_return_for_edit.click_return_for_edit_alert()
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
 
     # Assert errors appear
     assert (
@@ -629,7 +629,7 @@ def test_return_alert_for_edit(driver):
     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
         reason_for_returning_alert
     )
-    alert_page_with_return_for_edit.click_return_for_edit_alert()
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
     assert (
         alert_page_with_return_for_edit.get_returned_banner_text()
         == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -11,6 +11,7 @@ from tests.pages.locators import (
     NewPasswordPageLocators,
     PlatformAdminPageLocators,
     RejectionFormLocators,
+    ReturnForEditFormLocators,
     SearchCoordinatePageLocators,
     SearchPostcodePageLocators,
     SignUpPageLocators,
@@ -185,3 +186,7 @@ class RejectAlertButton(BasePageElement):
 
 class RejectionDetailLink:
     name = RejectionFormLocators.REJECTION_DETAIL_LINK[1]
+
+
+class ReturnForEditReasonTextArea(BasePageElement):
+    name = ReturnForEditFormLocators.RETURN_FOR_EDIT_REASON_TEXTAREA[1]

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -217,7 +217,7 @@ class ReturnForEditFormLocators(object):
     RETURN_FOR_EDIT_DETAIL_ELEMENT = (By.ID, "return_for_edit_reason")
     RETURN_FOR_EDIT_REASON_TEXTAREA = (By.ID, "return_for_edit_reason")
     RETURN_FOR_EDIT_ALERT_BUTTON = (By.NAME, "return-alert-for-edit")
-    RETURN_FOR_EDIT_BANNER = (By.ID, "returned-reason")
+    RETURN_FOR_EDIT_BANNER = (By.ID, "returned-reason-banner")
 
 
 class AdminApprovalPageLocators(object):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -206,7 +206,18 @@ class RejectionFormLocators(object):
     )
     REJECTION_DETAIL_ELEMENT = (By.ID, "rejection_reason_details")
     REJECTION_REASON_TEXTAREA = (By.ID, "rejection_reason")
-    REJECT_ALERT_BUTTON = (By.CLASS_NAME, "govuk-button--warning")
+    REJECT_ALERT_BUTTON = (By.NAME, "reject-alert")
+
+
+class ReturnForEditFormLocators(object):
+    RETURN_FOR_EDIT_DETAIL_LINK = (
+        By.XPATH,
+        '//*[@id="return_for_edit_reason"]/summary/span',
+    )
+    RETURN_FOR_EDIT_DETAIL_ELEMENT = (By.ID, "return_for_edit_reason")
+    RETURN_FOR_EDIT_REASON_TEXTAREA = (By.ID, "return_for_edit_reason")
+    RETURN_FOR_EDIT_ALERT_BUTTON = (By.NAME, "return-alert-for-edit")
+    RETURN_FOR_EDIT_BANNER = (By.ID, "returned-reason")
 
 
 class AdminApprovalPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1442,7 +1442,7 @@ class ReturnAlertForEditForm(BasePage):
         )
         return not element.get_attribute("open")
 
-    def click_return_for_edit_alert(self):
+    def click_return_alert_for_edit(self):
         element = self.wait_for_element(
             ReturnForEditFormLocators.RETURN_FOR_EDIT_ALERT_BUTTON
         )

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -41,6 +41,7 @@ from tests.pages.element import (
     RejectionDetailElement,
     RejectionDetailLink,
     RejectionReasonTextArea,
+    ReturnForEditReasonTextArea,
     SearchButton,
     SearchInputElement,
     SecondCoordinateInputElement,
@@ -62,6 +63,7 @@ from tests.pages.locators import (
     MainPageLocators,
     NavigationLocators,
     RejectionFormLocators,
+    ReturnForEditFormLocators,
     SearchCoordinatePageLocators,
     SearchPostcodePageLocators,
     ServiceSettingsLocators,
@@ -1417,6 +1419,48 @@ class RejectionForm(BasePage):
         error_message = (By.CSS_SELECTOR, ".govuk-error-message")
         errors = self.wait_for_element(error_message)
         return errors.text.strip()
+
+
+class ReturnAlertForEditForm(BasePage):
+    return_for_edit_reason_text_area = ReturnForEditReasonTextArea()
+
+    def click_open_return_for_edit_detail(self):
+        element = self.wait_for_element(
+            ReturnForEditFormLocators.RETURN_FOR_EDIT_DETAIL_LINK
+        )
+        element.click()
+
+    def return_for_edit_details_is_open(self):
+        element = self.wait_for_element(
+            ReturnForEditFormLocators.RETURN_FOR_EDIT_DETAIL_ELEMENT
+        )
+        return element.get_attribute("open")
+
+    def return_for_edit_details_is_closed(self):
+        element = self.wait_for_element(
+            ReturnForEditFormLocators.RETURN_FOR_EDIT_DETAIL_ELEMENT
+        )
+        return not element.get_attribute("open")
+
+    def click_return_for_edit_alert(self):
+        element = self.wait_for_element(
+            ReturnForEditFormLocators.RETURN_FOR_EDIT_ALERT_BUTTON
+        )
+        element.click()
+
+    def create_return_for_edit_reason_input(self, content):
+        self.return_for_edit_reason_text_area = content
+
+    def get_return_for_edit_form_errors(self):
+        error_message = (By.CSS_SELECTOR, ".govuk-error-message")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
+
+    def get_returned_banner_text(self):
+        element = self.wait_for_element(
+            ReturnForEditFormLocators.RETURN_FOR_EDIT_BANNER
+        )
+        return element.text.strip()
 
 
 class AdminApprovalsPage(BasePage):


### PR DESCRIPTION
This PR adds tests that assert that the "return for edit" functionality is working as expected.
This PR consists of:
- Addition of `test_return_alert_for_edit` test
- `ReturnAlertForEditForm` page and relevant locators and methods
- Pinned version of boto3 to avoid backtracking that can be seen in the PR checks history