### PR TITLE
EAS-2629 Python upgrade

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -15,7 +15,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.9
+      python: 3.12
 
     commands:
       - apt update
@@ -39,11 +39,11 @@ phases:
     commands:
       - cd $CODEBUILD_SRC_DIR
       - VENV_TESTS='/venv/eas-tests'
-      - python3.9 -m venv $VENV_TESTS
+      - python3.12 -m venv $VENV_TESTS
       - . $VENV_TESTS/bin/activate
       - chmod +x environment.sh
       - . ./environment.sh
-      - python3.9 -m pip install --upgrade pip==25.0.1 wheel setuptools
+      - python3.12 -m pip install --upgrade pip wheel setuptools
       - make bootstrap
 
   build:
@@ -70,7 +70,7 @@ phases:
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
           export testsuites="$testsuites cbc-integration"
         fi
-        python3.9 ./scripts/report-test-results.py $(pwd) $testsuites
+        python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:
     commands:
@@ -78,7 +78,7 @@ phases:
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
           export testsuites="$testsuites cbc-integration"
         fi
-      - python3.9 ./scripts/signal-build-pass-or-fail.py $(pwd) $testsuites
+      - python3.12 ./scripts/signal-build-pass-or-fail.py $(pwd) $testsuites
 
 artifacts:
   files:

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -1,7 +1,7 @@
 name: on-pr-into-main
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.12
 
 on:
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ lint:
 	flake8 .
 	black --check .
 
+.PHONY: uninstall-packages
+uninstall-packages:
+	python -m pip freeze | xargs python -m pip uninstall -y
+
 .PHONY: test-broadcast-flow
 test-broadcast-flow:
 	pytest -v -n auto --dist=loadgroup \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.5.1
-boto3==1.28.0
+boto3>=1.38.10
 black==24.3.0
 Flask>=0.11.1
 Flask-Cache==0.13.1

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -176,9 +176,11 @@ def test_prepare_broadcast_with_template(driver):
 @pytest.mark.xdist_group(name=test_group_name)
 def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
+        datetime.now(timezone.utc) - timedelta(hours=1)
     )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
     identifier = uuid.uuid4()
     event = f"test broadcast {identifier}"
     broadcast_content = f"Flood warning {identifier} has been issued"
@@ -216,9 +218,11 @@ def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client
 @pytest.mark.xdist_group(name=test_group_name)
 def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.utcnow() - timedelta(hours=1)
+        datetime.now(timezone.utc) - timedelta(hours=1)
     )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(datetime.utcnow())
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
     identifier = uuid.uuid4()
     event = f"test broadcast {identifier}"
     broadcast_content = f"Flood warning {identifier} has been issued"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,8 @@ from tests.pages import (
 )
 
 logging.basicConfig(
-    filename="./logs/test_run_{}.log".format(datetime.utcnow()), level=logging.INFO
+    filename="./logs/test_run_{}.log".format(datetime.now(timezone.utc)),
+    level=logging.INFO,
 )
 
 ACCOUNTS_REQUIRING_SMS_2FA = [
@@ -211,11 +212,11 @@ def recordtime(func):
     def wrapper(*args, **kwargs):
         try:
             logging.info("Starting Test: {}".format(func.__name__))
-            logging.info("Start Time: {}".format(str(datetime.utcnow())))
+            logging.info("Start Time: {}".format(str(datetime.now(timezone.utc))))
             result = func(*args, **kwargs)
             return result
         finally:
-            logging.info("End Time: {}".format(str(datetime.utcnow())))
+            logging.info("End Time: {}".format(str(datetime.now(timezone.utc))))
 
     return wrapper
 


### PR DESCRIPTION
- Upgrade functional test runtime to 3.12
- Remove calls to deprecated utcnow() method
- Add wait loops to some functional test steps