### PR TITLE
EAS-2687 Adds extra content functional test

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,13 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
+      session-timeout
 
 phases:
   install:
@@ -45,7 +52,24 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          make test-cbc-integration; exit 0
+        else
+          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
+        fi
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          export testsuites="$testsuites cbc-integration"
+        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -52,24 +45,7 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          make test-cbc-integration; exit 0
-        else
-          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
-        fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
       - echo "Test run completed."
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          export testsuites="$testsuites cbc-integration"
-        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -719,7 +719,7 @@ def test_prepare_broadcast_with_extra_content(driver):
 
     time.sleep(10)
     check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content, extra_content
+        driver, "Current alerts", broadcast_content
     )
 
     # get back to the alert page
@@ -736,7 +736,9 @@ def test_prepare_broadcast_with_extra_content(driver):
     assert past_alerts_page.text_is_on_page(broadcast_title)
 
     time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Past alerts", broadcast_content, extra_content
+    )
 
     current_alerts_page.get()
     current_alerts_page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -719,7 +719,7 @@ def test_prepare_broadcast_with_extra_content(driver):
 
     time.sleep(10)
     check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
+        driver, "Current alerts", broadcast_content, extra_content
     )
 
     # get back to the alert page
@@ -736,9 +736,7 @@ def test_prepare_broadcast_with_extra_content(driver):
     assert past_alerts_page.text_is_on_page(broadcast_title)
 
     time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Past alerts", broadcast_content, extra_content
-    )
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
     current_alerts_page.get()
     current_alerts_page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,658 +1,683 @@
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from tests.pages import BasePage, BroadcastDurationPage, BroadcastFreeformPage
-from tests.pages.pages import ExtraContentPage
+from config import config
+from tests.functional.preview_and_dev.sample_cap_xml import (
+    ALERT_XML,
+    CANCEL_XML,
+)
+from tests.pages import (
+    BasePage,
+    BroadcastDurationPage,
+    BroadcastFreeformPage,
+    CurrentAlertsPage,
+    ShowTemplatesPage,
+)
+from tests.pages.pages import (
+    ChooseCoordinateArea,
+    ChooseCoordinatesType,
+    ExtraContentPage,
+    RejectionForm,
+    ReturnAlertForEditForm,
+    SearchPostcodePage,
+)
 from tests.pages.rollups import sign_in
-from tests.test_utils import check_alert_is_published_on_govuk_alerts
+from tests.test_utils import (
+    check_alert_is_published_on_govuk_alerts,
+    convert_naive_utc_datetime_to_cap_standard_string,
+    create_broadcast_template,
+    delete_template,
+    go_to_templates_page,
+)
 
 test_group_name = "broadcast-flow"
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast " + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_template(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     go_to_templates_page(driver, service="broadcast_service")
-#     template_name = "test broadcast" + str(uuid.uuid4())
-#     content = "This is a test only."
-#     create_broadcast_template(driver, name=template_name, content=content)
-
-#     current_alerts_page = CurrentAlertsPage(driver)
-#     current_alerts_page.go_to_service_landing_page(
-#         service_id=config["broadcast_service"]["id"]
-#     )
-#     current_alerts_page.click_element_by_link_text("Current alerts")
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="template")
-#     new_alert_page.click_continue()
-
-#     templates_page = ShowTemplatesPage(driver)
-#     templates_page.click_template_by_link_text(template_name)
-
-#     templates_page.click_element_by_link_text("Save and get ready to send")
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert prepare_alert_pages.text_is_on_page("Cokeham")
-#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{template_name} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
-#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.text_is_on_page(template_name)
-
-#     delete_template(driver, template_name, service="broadcast_service")
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc) - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc)
-#     )
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
-
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
-
-#     sign_in(driver, account_type="broadcast_approve_user")
-#     page = BasePage(driver)
-#     page.click_element_by_link_text(event)
-
-#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
-
-#     reject_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
-
-#     time.sleep(10)
-#     page.click_element_by_link_text("Rejected alerts")
-#     assert page.text_is_on_page(event)
-
-#     page.get()
-#     page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc) - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc)
-#     )
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
-
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
-
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     page = BasePage(driver)
-#     page.click_element_by_link_text(event)
-#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     page.click_submit()
-
-#     assert page.text_is_on_page("since today at")
-
-#     alert_page_url = page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     cancel_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
-
-#     # go back to the page for the current alert
-#     time.sleep(10)
-#     page.get(alert_page_url)
-
-#     # assert that it's now cancelled
-#     assert page.text_is_on_page("Stopped by an API call")
-#     page.click_element_by_link_text("Past alerts")
-#     assert page.text_is_on_page(event)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     page.get()
-#     page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
-#     # This is where it varies
-#     search_postcode_page = SearchPostcodePage(driver)
-#     postcode_to_search = "BD1 1EE"
-#     radius_to_add = "5"
-#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-#     search_postcode_page.click_search()
-#     # assert areas appear here
-
-#     search_postcode_page.click_continue()
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # here check if selected areas displayed
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page(
-#         "5km around the postcode BD1 1EE in Bradford"
-#     )
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# @pytest.mark.parametrize(
-#     "coordinate_type, post_data, expected_area_description",
-#     (
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "416567",
-#                 "second_coordinate": "432994",
-#                 "radius": "3",
-#             },
-#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
-#         ),
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "419763",
-#                 "second_coordinate": "456038",
-#                 "radius": "5",
-#             },
-#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-#         ),
-#     ),
-# )
-# def test_prepare_broadcast_with_new_content_for_coordinate_area(
-#     driver, coordinate_type, post_data, expected_area_description
-# ):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast{test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Coordinates")
-#     # This is where it varies
-#     choose_type_page = ChooseCoordinatesType(driver)
-#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-#     choose_type_page.click_continue()
-
-#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
-#     choose_coordinate_area_page.create_coordinate_area(
-#         post_data["first_coordinate"],
-#         post_data["second_coordinate"],
-#         post_data["radius"],
-#     )
-#     choose_coordinate_area_page.click_search()
-#     choose_coordinate_area_page.click_continue()
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # here check if selected areas displayed
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page(expected_area_description)
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_reject_alert_with_reason(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast {test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # reject the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-#     alert_page_with_rejection = RejectionForm(driver)
-#     assert alert_page_with_rejection.rejection_details_is_closed()
-#     alert_page_with_rejection.click_open_reject_detail()
-#     assert alert_page_with_rejection.rejection_details_is_open()
-
-#     # Without rejection reason
-#     rejection_reason = ""
-#     alert_page_with_rejection.click_reject_alert()
-
-#     # Assert errors appear
-#     assert (
-#         alert_page_with_rejection.get_rejection_form_errors()
-#         == "Error:\nEnter the reason for rejecting the alert"
-#     )
-
-#     # With rejection reason
-#     rejection_reason = "This is a test rejection reason."
-#     alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
-#     alert_page_with_rejection.click_reject_alert()
-
-#     assert current_alerts_page.text_is_on_page("Current alerts")
-#     current_alerts_page.click_element_by_link_text("Rejected alerts")
-
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.text_is_on_page(broadcast_title)
-#     assert rejected_alerts_page.text_is_on_page(rejection_reason)
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_return_alert_for_edit(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast {test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # Return the alert for edit
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-#     alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
-#     assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
-#     alert_page_with_return_for_edit.click_open_return_for_edit_detail()
-#     assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
-
-#     # Without rejection reason
-#     reason_for_returning_alert = ""
-#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-#         reason_for_returning_alert
-#     )
-#     alert_page_with_return_for_edit.click_return_alert_for_edit()
-
-#     # Assert errors appear
-#     assert (
-#         alert_page_with_return_for_edit.get_return_for_edit_form_errors()
-#         == "Error:\nEnter the reason for returning the alert for edit"
-#     )
-
-#     # With reason for returning alert for edit
-#     reason_for_returning_alert = (
-#         "This is a test reason for returning the alert for edit."
-#     )
-#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-#         reason_for_returning_alert
-#     )
-#     alert_page_with_return_for_edit.click_return_alert_for_edit()
-#     assert (
-#         f"This alert has been returned to edit, because: {reason_for_returning_alert}"
-#         in alert_page_with_return_for_edit.get_returned_banner_text()
-#     )
-#     assert alert_page_with_return_for_edit.text_is_on_page(
-#         "Submitted by Functional Tests - Broadcast User Create"
-#     )
-#     assert alert_page_with_return_for_edit.text_is_on_page(
-#         "Returned by Functional Tests - Broadcast User Approve"
-#     )
-
-#     assert current_alerts_page.text_is_on_page("Current alerts")
-#     assert current_alerts_page.text_is_on_page(broadcast_title)
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_template(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    go_to_templates_page(driver, service="broadcast_service")
+    template_name = "test broadcast" + str(uuid.uuid4())
+    content = "This is a test only."
+    create_broadcast_template(driver, name=template_name, content=content)
+
+    current_alerts_page = CurrentAlertsPage(driver)
+    current_alerts_page.go_to_service_landing_page(
+        service_id=config["broadcast_service"]["id"]
+    )
+    current_alerts_page.click_element_by_link_text("Current alerts")
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="template")
+    new_alert_page.click_continue()
+
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
+
+    templates_page.click_element_by_link_text("Save and get ready to send")
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert prepare_alert_pages.text_is_on_page("Cokeham")
+    assert prepare_alert_pages.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{template_name} is waiting for approval"
+    )
+
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.text_is_on_page(template_name)
+
+    delete_template(driver, template_name, service="broadcast_service")
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
+
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type="broadcast_approve_user")
+    page = BasePage(driver)
+    page.click_element_by_link_text(event)
+
+    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+
+    reject_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(reject_broadcast_xml)
+
+    time.sleep(10)
+    page.click_element_by_link_text("Rejected alerts")
+    assert page.text_is_on_page(event)
+
+    page.get()
+    page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
+
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
+
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    page = BasePage(driver)
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_submit()
+
+    assert page.text_is_on_page("since today at")
+
+    alert_page_url = page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+    # go back to the page for the current alert
+    time.sleep(10)
+    page.get(alert_page_url)
+
+    # assert that it's now cancelled
+    assert page.text_is_on_page("Stopped by an API call")
+    page.click_element_by_link_text("Past alerts")
+    assert page.text_is_on_page(event)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    page.get()
+    page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Postcode areas")
+    # This is where it varies
+    search_postcode_page = SearchPostcodePage(driver)
+    postcode_to_search = "BD1 1EE"
+    radius_to_add = "5"
+    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+    search_postcode_page.click_search()
+    # assert areas appear here
+
+    search_postcode_page.click_continue()
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # here check if selected areas displayed
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page(
+        "5km around the postcode BD1 1EE in Bradford"
+    )
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "coordinate_type, post_data, expected_area_description",
+    (
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "416567",
+                "second_coordinate": "432994",
+                "radius": "3",
+            },
+            "3km around the easting of 416567 and the northing of 432994 in Bradford",
+        ),
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "419763",
+                "second_coordinate": "456038",
+                "radius": "5",
+            },
+            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+            "3km around 53.793 latitude, -1.75 longitude in Bradford",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_new_content_for_coordinate_area(
+    driver, coordinate_type, post_data, expected_area_description
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast{test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Coordinates")
+    # This is where it varies
+    choose_type_page = ChooseCoordinatesType(driver)
+    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+    choose_type_page.click_continue()
+
+    choose_coordinate_area_page = ChooseCoordinateArea(driver)
+    choose_coordinate_area_page.create_coordinate_area(
+        post_data["first_coordinate"],
+        post_data["second_coordinate"],
+        post_data["radius"],
+    )
+    choose_coordinate_area_page.click_search()
+    choose_coordinate_area_page.click_continue()
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # here check if selected areas displayed
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page(expected_area_description)
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_reject_alert_with_reason(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast {test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # reject the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_rejection = RejectionForm(driver)
+    assert alert_page_with_rejection.rejection_details_is_closed()
+    alert_page_with_rejection.click_open_reject_detail()
+    assert alert_page_with_rejection.rejection_details_is_open()
+
+    # Without rejection reason
+    rejection_reason = ""
+    alert_page_with_rejection.click_reject_alert()
+
+    # Assert errors appear
+    assert (
+        alert_page_with_rejection.get_rejection_form_errors()
+        == "Error:\nEnter the reason for rejecting the alert"
+    )
+
+    # With rejection reason
+    rejection_reason = "This is a test rejection reason."
+    alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
+    alert_page_with_rejection.click_reject_alert()
+
+    assert current_alerts_page.text_is_on_page("Current alerts")
+    current_alerts_page.click_element_by_link_text("Rejected alerts")
+
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.text_is_on_page(broadcast_title)
+    assert rejected_alerts_page.text_is_on_page(rejection_reason)
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_return_alert_for_edit(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast {test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # Return the alert for edit
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
+    alert_page_with_return_for_edit.click_open_return_for_edit_detail()
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
+
+    # Without rejection reason
+    reason_for_returning_alert = ""
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
+
+    # Assert errors appear
+    assert (
+        alert_page_with_return_for_edit.get_return_for_edit_form_errors()
+        == "Error:\nEnter the reason for returning the alert for edit"
+    )
+
+    # With reason for returning alert for edit
+    reason_for_returning_alert = (
+        "This is a test reason for returning the alert for edit."
+    )
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
+    assert (
+        f"This alert has been returned to edit, because: {reason_for_returning_alert}"
+        in alert_page_with_return_for_edit.get_returned_banner_text()
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Submitted by Functional Tests - Broadcast User Create"
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Returned by Functional Tests - Broadcast User Approve"
+    )
+
+    assert current_alerts_page.text_is_on_page("Current alerts")
+    assert current_alerts_page.text_is_on_page(broadcast_title)
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -19,6 +19,7 @@ from tests.pages import (
 from tests.pages.pages import (
     ChooseCoordinateArea,
     ChooseCoordinatesType,
+    ExtraContentPage,
     RejectionForm,
     ReturnAlertForEditForm,
     SearchPostcodePage,
@@ -54,6 +55,11 @@ def test_prepare_broadcast_with_new_content(driver):
     broadcast_content = "This is a test broadcast " + test_uuid
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
+
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
 
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
@@ -138,6 +144,11 @@ def test_prepare_broadcast_with_template(driver):
     templates_page.click_template_by_link_text(template_name)
 
     templates_page.click_element_by_link_text("Save and get ready to send")
+
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
 
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
@@ -295,6 +306,11 @@ def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Postcode areas")
     # This is where it varies
@@ -414,6 +430,11 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Coordinates")
     # This is where it varies
@@ -500,6 +521,11 @@ def test_reject_alert_with_reason(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
@@ -578,6 +604,11 @@ def test_return_alert_for_edit(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
+    # Choosing not to add exra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
@@ -635,8 +666,8 @@ def test_return_alert_for_edit(driver):
     )
     alert_page_with_return_for_edit.click_return_alert_for_edit()
     assert (
-        alert_page_with_return_for_edit.get_returned_banner_text()
-        == f"Reason why alert has been returned to edit: {reason_for_returning_alert}"
+        f"This alert has been returned to edit, because {reason_for_returning_alert}"
+        in alert_page_with_return_for_edit.get_returned_banner_text()
     )
     assert alert_page_with_return_for_edit.text_is_on_page(
         "Submitted by Functional Tests - Broadcast User Create"
@@ -647,3 +678,92 @@ def test_return_alert_for_edit(driver):
 
     assert current_alerts_page.text_is_on_page("Current alerts")
     assert current_alerts_page.text_is_on_page(broadcast_title)
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_extra_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing to add exra_content to alert
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="yes")
+    choose_extra_content_page.click_continue()
+
+    # Adding extra_content to textarea and submitting
+    add_extra_content_page = ExtraContentPage(driver)
+    extra_content = "This is extra content " + test_uuid
+    add_extra_content_page.create_extra_content(extra_content)
+    add_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Countries")
+    prepare_alert_pages.select_checkbox_or_radio(value="ctry19-W92000004")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Wales")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Past alerts", broadcast_content, extra_content
+    )
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1,683 +1,658 @@
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from config import config
-from tests.functional.preview_and_dev.sample_cap_xml import (
-    ALERT_XML,
-    CANCEL_XML,
-)
-from tests.pages import (
-    BasePage,
-    BroadcastDurationPage,
-    BroadcastFreeformPage,
-    CurrentAlertsPage,
-    ShowTemplatesPage,
-)
-from tests.pages.pages import (
-    ChooseCoordinateArea,
-    ChooseCoordinatesType,
-    ExtraContentPage,
-    RejectionForm,
-    ReturnAlertForEditForm,
-    SearchPostcodePage,
-)
+from tests.pages import BasePage, BroadcastDurationPage, BroadcastFreeformPage
+from tests.pages.pages import ExtraContentPage
 from tests.pages.rollups import sign_in
-from tests.test_utils import (
-    check_alert_is_published_on_govuk_alerts,
-    convert_naive_utc_datetime_to_cap_standard_string,
-    create_broadcast_template,
-    delete_template,
-    go_to_templates_page,
-)
+from tests.test_utils import check_alert_is_published_on_govuk_alerts
 
 test_group_name = "broadcast-flow"
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast " + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_template(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    go_to_templates_page(driver, service="broadcast_service")
-    template_name = "test broadcast" + str(uuid.uuid4())
-    content = "This is a test only."
-    create_broadcast_template(driver, name=template_name, content=content)
-
-    current_alerts_page = CurrentAlertsPage(driver)
-    current_alerts_page.go_to_service_landing_page(
-        service_id=config["broadcast_service"]["id"]
-    )
-    current_alerts_page.click_element_by_link_text("Current alerts")
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="template")
-    new_alert_page.click_continue()
-
-    templates_page = ShowTemplatesPage(driver)
-    templates_page.click_template_by_link_text(template_name)
-
-    templates_page.click_element_by_link_text("Save and get ready to send")
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert prepare_alert_pages.text_is_on_page("Cokeham")
-    assert prepare_alert_pages.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{template_name} is waiting for approval"
-    )
-
-    prepare_alert_pages.click_element_by_link_text("Discard this alert")
-    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.text_is_on_page(template_name)
-
-    delete_template(driver, template_name, service="broadcast_service")
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc) - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc)
-    )
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
-
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
-
-    sign_in(driver, account_type="broadcast_approve_user")
-    page = BasePage(driver)
-    page.click_element_by_link_text(event)
-
-    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
-
-    reject_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(reject_broadcast_xml)
-
-    time.sleep(10)
-    page.click_element_by_link_text("Rejected alerts")
-    assert page.text_is_on_page(event)
-
-    page.get()
-    page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc) - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc)
-    )
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
-
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
-
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    page = BasePage(driver)
-    page.click_element_by_link_text(event)
-    page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    page.click_submit()
-
-    assert page.text_is_on_page("since today at")
-
-    alert_page_url = page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    cancel_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
-
-    # go back to the page for the current alert
-    time.sleep(10)
-    page.get(alert_page_url)
-
-    # assert that it's now cancelled
-    assert page.text_is_on_page("Stopped by an API call")
-    page.click_element_by_link_text("Past alerts")
-    assert page.text_is_on_page(event)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    page.get()
-    page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Postcode areas")
-    # This is where it varies
-    search_postcode_page = SearchPostcodePage(driver)
-    postcode_to_search = "BD1 1EE"
-    radius_to_add = "5"
-    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-    search_postcode_page.click_search()
-    # assert areas appear here
-
-    search_postcode_page.click_continue()
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # here check if selected areas displayed
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page(
-        "5km around the postcode BD1 1EE in Bradford"
-    )
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-@pytest.mark.parametrize(
-    "coordinate_type, post_data, expected_area_description",
-    (
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "416567",
-                "second_coordinate": "432994",
-                "radius": "3",
-            },
-            "3km around the easting of 416567 and the northing of 432994 in Bradford",
-        ),
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "419763",
-                "second_coordinate": "456038",
-                "radius": "5",
-            },
-            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-            "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
-        ),
-    ),
-)
-def test_prepare_broadcast_with_new_content_for_coordinate_area(
-    driver, coordinate_type, post_data, expected_area_description
-):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast{test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Coordinates")
-    # This is where it varies
-    choose_type_page = ChooseCoordinatesType(driver)
-    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-    choose_type_page.click_continue()
-
-    choose_coordinate_area_page = ChooseCoordinateArea(driver)
-    choose_coordinate_area_page.create_coordinate_area(
-        post_data["first_coordinate"],
-        post_data["second_coordinate"],
-        post_data["radius"],
-    )
-    choose_coordinate_area_page.click_search()
-    choose_coordinate_area_page.click_continue()
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # here check if selected areas displayed
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page(expected_area_description)
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_reject_alert_with_reason(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast {test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # reject the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-    alert_page_with_rejection = RejectionForm(driver)
-    assert alert_page_with_rejection.rejection_details_is_closed()
-    alert_page_with_rejection.click_open_reject_detail()
-    assert alert_page_with_rejection.rejection_details_is_open()
-
-    # Without rejection reason
-    rejection_reason = ""
-    alert_page_with_rejection.click_reject_alert()
-
-    # Assert errors appear
-    assert (
-        alert_page_with_rejection.get_rejection_form_errors()
-        == "Error:\nEnter the reason for rejecting the alert"
-    )
-
-    # With rejection reason
-    rejection_reason = "This is a test rejection reason."
-    alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
-    alert_page_with_rejection.click_reject_alert()
-
-    assert current_alerts_page.text_is_on_page("Current alerts")
-    current_alerts_page.click_element_by_link_text("Rejected alerts")
-
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.text_is_on_page(broadcast_title)
-    assert rejected_alerts_page.text_is_on_page(rejection_reason)
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_return_alert_for_edit(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast {test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # Return the alert for edit
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-    alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
-    assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
-    alert_page_with_return_for_edit.click_open_return_for_edit_detail()
-    assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
-
-    # Without rejection reason
-    reason_for_returning_alert = ""
-    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-        reason_for_returning_alert
-    )
-    alert_page_with_return_for_edit.click_return_alert_for_edit()
-
-    # Assert errors appear
-    assert (
-        alert_page_with_return_for_edit.get_return_for_edit_form_errors()
-        == "Error:\nEnter the reason for returning the alert for edit"
-    )
-
-    # With reason for returning alert for edit
-    reason_for_returning_alert = (
-        "This is a test reason for returning the alert for edit."
-    )
-    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-        reason_for_returning_alert
-    )
-    alert_page_with_return_for_edit.click_return_alert_for_edit()
-    assert (
-        f"This alert has been returned to edit, because: {reason_for_returning_alert}"
-        in alert_page_with_return_for_edit.get_returned_banner_text()
-    )
-    assert alert_page_with_return_for_edit.text_is_on_page(
-        "Submitted by Functional Tests - Broadcast User Create"
-    )
-    assert alert_page_with_return_for_edit.text_is_on_page(
-        "Returned by Functional Tests - Broadcast User Approve"
-    )
-
-    assert current_alerts_page.text_is_on_page("Current alerts")
-    assert current_alerts_page.text_is_on_page(broadcast_title)
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast " + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_template(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     go_to_templates_page(driver, service="broadcast_service")
+#     template_name = "test broadcast" + str(uuid.uuid4())
+#     content = "This is a test only."
+#     create_broadcast_template(driver, name=template_name, content=content)
+
+#     current_alerts_page = CurrentAlertsPage(driver)
+#     current_alerts_page.go_to_service_landing_page(
+#         service_id=config["broadcast_service"]["id"]
+#     )
+#     current_alerts_page.click_element_by_link_text("Current alerts")
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="template")
+#     new_alert_page.click_continue()
+
+#     templates_page = ShowTemplatesPage(driver)
+#     templates_page.click_template_by_link_text(template_name)
+
+#     templates_page.click_element_by_link_text("Save and get ready to send")
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert prepare_alert_pages.text_is_on_page("Cokeham")
+#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{template_name} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
+#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.text_is_on_page(template_name)
+
+#     delete_template(driver, template_name, service="broadcast_service")
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc) - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc)
+#     )
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
+
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
+
+#     sign_in(driver, account_type="broadcast_approve_user")
+#     page = BasePage(driver)
+#     page.click_element_by_link_text(event)
+
+#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+
+#     reject_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
+
+#     time.sleep(10)
+#     page.click_element_by_link_text("Rejected alerts")
+#     assert page.text_is_on_page(event)
+
+#     page.get()
+#     page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc) - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc)
+#     )
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
+
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
+
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     page = BasePage(driver)
+#     page.click_element_by_link_text(event)
+#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     page.click_submit()
+
+#     assert page.text_is_on_page("since today at")
+
+#     alert_page_url = page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     cancel_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+#     # go back to the page for the current alert
+#     time.sleep(10)
+#     page.get(alert_page_url)
+
+#     # assert that it's now cancelled
+#     assert page.text_is_on_page("Stopped by an API call")
+#     page.click_element_by_link_text("Past alerts")
+#     assert page.text_is_on_page(event)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     page.get()
+#     page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
+#     # This is where it varies
+#     search_postcode_page = SearchPostcodePage(driver)
+#     postcode_to_search = "BD1 1EE"
+#     radius_to_add = "5"
+#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+#     search_postcode_page.click_search()
+#     # assert areas appear here
+
+#     search_postcode_page.click_continue()
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # here check if selected areas displayed
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page(
+#         "5km around the postcode BD1 1EE in Bradford"
+#     )
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# @pytest.mark.parametrize(
+#     "coordinate_type, post_data, expected_area_description",
+#     (
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "416567",
+#                 "second_coordinate": "432994",
+#                 "radius": "3",
+#             },
+#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
+#         ),
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "419763",
+#                 "second_coordinate": "456038",
+#                 "radius": "5",
+#             },
+#             "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
+#             "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
+#         ),
+#     ),
+# )
+# def test_prepare_broadcast_with_new_content_for_coordinate_area(
+#     driver, coordinate_type, post_data, expected_area_description
+# ):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast{test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Coordinates")
+#     # This is where it varies
+#     choose_type_page = ChooseCoordinatesType(driver)
+#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+#     choose_type_page.click_continue()
+
+#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
+#     choose_coordinate_area_page.create_coordinate_area(
+#         post_data["first_coordinate"],
+#         post_data["second_coordinate"],
+#         post_data["radius"],
+#     )
+#     choose_coordinate_area_page.click_search()
+#     choose_coordinate_area_page.click_continue()
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # here check if selected areas displayed
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page(expected_area_description)
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_reject_alert_with_reason(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast {test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # reject the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+#     alert_page_with_rejection = RejectionForm(driver)
+#     assert alert_page_with_rejection.rejection_details_is_closed()
+#     alert_page_with_rejection.click_open_reject_detail()
+#     assert alert_page_with_rejection.rejection_details_is_open()
+
+#     # Without rejection reason
+#     rejection_reason = ""
+#     alert_page_with_rejection.click_reject_alert()
+
+#     # Assert errors appear
+#     assert (
+#         alert_page_with_rejection.get_rejection_form_errors()
+#         == "Error:\nEnter the reason for rejecting the alert"
+#     )
+
+#     # With rejection reason
+#     rejection_reason = "This is a test rejection reason."
+#     alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
+#     alert_page_with_rejection.click_reject_alert()
+
+#     assert current_alerts_page.text_is_on_page("Current alerts")
+#     current_alerts_page.click_element_by_link_text("Rejected alerts")
+
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.text_is_on_page(broadcast_title)
+#     assert rejected_alerts_page.text_is_on_page(rejection_reason)
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_return_alert_for_edit(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast {test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # Return the alert for edit
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+#     alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
+#     assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
+#     alert_page_with_return_for_edit.click_open_return_for_edit_detail()
+#     assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
+
+#     # Without rejection reason
+#     reason_for_returning_alert = ""
+#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+#         reason_for_returning_alert
+#     )
+#     alert_page_with_return_for_edit.click_return_alert_for_edit()
+
+#     # Assert errors appear
+#     assert (
+#         alert_page_with_return_for_edit.get_return_for_edit_form_errors()
+#         == "Error:\nEnter the reason for returning the alert for edit"
+#     )
+
+#     # With reason for returning alert for edit
+#     reason_for_returning_alert = (
+#         "This is a test reason for returning the alert for edit."
+#     )
+#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+#         reason_for_returning_alert
+#     )
+#     alert_page_with_return_for_edit.click_return_alert_for_edit()
+#     assert (
+#         f"This alert has been returned to edit, because: {reason_for_returning_alert}"
+#         in alert_page_with_return_for_edit.get_returned_banner_text()
+#     )
+#     assert alert_page_with_return_for_edit.text_is_on_page(
+#         "Submitted by Functional Tests - Broadcast User Create"
+#     )
+#     assert alert_page_with_return_for_edit.text_is_on_page(
+#         "Returned by Functional Tests - Broadcast User Approve"
+#     )
+
+#     assert current_alerts_page.text_is_on_page("Current alerts")
+#     assert current_alerts_page.text_is_on_page(broadcast_title)
 
 
 @pytest.mark.xdist_group(name=test_group_name)

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -56,7 +56,7 @@ def test_prepare_broadcast_with_new_content(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()
@@ -145,7 +145,7 @@ def test_prepare_broadcast_with_template(driver):
 
     templates_page.click_element_by_link_text("Save and get ready to send")
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()
@@ -306,7 +306,7 @@ def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()
@@ -430,7 +430,7 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()
@@ -521,7 +521,7 @@ def test_reject_alert_with_reason(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()
@@ -604,7 +604,7 @@ def test_return_alert_for_edit(driver):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add exra_content
+    # Choosing not to add extra_content
     choose_extra_content_page = BasePage(driver)
     choose_extra_content_page.select_checkbox_or_radio(value="no")
     choose_extra_content_page.click_continue()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -666,7 +666,7 @@ def test_return_alert_for_edit(driver):
     )
     alert_page_with_return_for_edit.click_return_alert_for_edit()
     assert (
-        f"This alert has been returned to edit, because {reason_for_returning_alert}"
+        f"This alert has been returned to edit, because: {reason_for_returning_alert}"
         in alert_page_with_return_for_edit.get_returned_banner_text()
     )
     assert alert_page_with_return_for_edit.text_is_on_page(

--- a/tests/functional/preview_and_dev/test_template_flow.py
+++ b/tests/functional/preview_and_dev/test_template_flow.py
@@ -14,6 +14,7 @@ from tests.pages import (
     TeamMembersPage,
     ViewFolderPage,
 )
+from tests.pages.pages import BasePage
 from tests.pages.rollups import sign_in
 from tests.test_utils import go_to_templates_page
 
@@ -118,6 +119,11 @@ def test_create_prep_to_send_and_delete_template(driver):
     assert edit_template.text_is_on_page(alert_content)
 
     edit_template.click_prep_to_send()
+
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     assert edit_template.is_page_title("Choose where to send this alert")
     edit_template.click_templates()
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -8,6 +8,7 @@ from tests.pages.locators import (
     DashboardWithDialogPageLocators,
     DurationPageLocators,
     EditTemplatePageLocators,
+    ExtraContentPageLocators,
     NewPasswordPageLocators,
     PlatformAdminPageLocators,
     RejectionFormLocators,
@@ -98,6 +99,10 @@ class MobileInputElement(BasePageElement):
 
 class TemplateContentElement(BasePageElement):
     name = EditTemplatePageLocators.TEMPLATE_CONTENT_INPUT[1]
+
+
+class ExtraContentElement(BasePageElement):
+    name = ExtraContentPageLocators.EXTRA_CONTENT_INPUT[1]
 
 
 class SubjectInputElement(BasePageElement):

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -87,6 +87,15 @@ class EditTemplatePageLocators(object):
     CONFIRM_DELETE_BUTTON = (By.NAME, "delete")
 
 
+class ExtraContentPageLocators(object):
+    EXTRA_CONTENT_INPUT = (By.NAME, "extra_content")
+    SAVE_BUTTON = (By.CSS_SELECTOR, "main button.govuk-button")
+    DISCARD_LINK = (
+        By.XPATH,
+        "//a[contains(@class, 'govuk-link') and contains(text(),'No longer required, return to alert')]",
+    )
+
+
 class TeamMembersPageLocators(object):
     H1 = (By.TAG_NAME, "h1")
     INVITE_TEAM_MEMBER_BUTTON = (By.CSS_SELECTOR, "a.govuk-button")

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -90,10 +90,6 @@ class EditTemplatePageLocators(object):
 class ExtraContentPageLocators(object):
     EXTRA_CONTENT_INPUT = (By.NAME, "extra_content")
     SAVE_BUTTON = (By.CSS_SELECTOR, "main button.govuk-button")
-    DISCARD_LINK = (
-        By.XPATH,
-        "//a[contains(@class, 'govuk-link') and contains(text(),'No longer required, return to alert')]",
-    )
 
 
 class TeamMembersPageLocators(object):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1276,11 +1276,6 @@ class GovUkAlertsPage(BasePage):
                 f'Could not find alert with extra content "{extra_content}"'
             )
 
-    def find_alert_page(self, extra_content):
-        return self.driver.find_elements(
-            By.XPATH, f"//div[contains(text(), '{extra_content}')]//a"
-        ).get_attribute("href")
-
 
 class BroadcastDurationPage(BasePage):
     hours_input = HoursInputElement(name="hours")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -23,6 +23,7 @@ from tests.pages.element import (
     EmailInputElement,
     ExpiryDialog,
     ExpiryDialogContinueButton,
+    ExtraContentElement,
     FeedbackTextAreaElement,
     FirstCoordinateInputElement,
     HoursInputElement,
@@ -59,6 +60,7 @@ from tests.pages.locators import (
     CommonPageLocators,
     DashboardWithDialogPageLocators,
     EditTemplatePageLocators,
+    ExtraContentPageLocators,
     InviteUserPageLocators,
     MainPageLocators,
     NavigationLocators,
@@ -1236,6 +1238,17 @@ class BroadcastFreeformPage(BasePage):
         self.content_input = content
 
 
+class ExtraContentPage(BasePage):
+    extra_content_input = ExtraContentElement()
+
+    def create_extra_content(self, extra_content):
+        self.extra_content_input = extra_content
+
+    def click_no_longer_required(self):
+        element = self.wait_for_element(ExtraContentPageLocators.DISCARD_LINK[1])
+        element.click()
+
+
 class GovUkAlertsPage(BasePage):
     def __init__(self, driver):
         self.gov_uk_alerts_url = config["govuk_alerts_url"]
@@ -1254,6 +1267,13 @@ class GovUkAlertsPage(BasePage):
             self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
+            )
+
+    def check_extra_content_appears(self, extra_content):
+        if not self.text_is_on_page(extra_content):
+            self.driver.refresh()
+            raise RetryException(
+                f'Could not find alert with extra content "{extra_content}"'
             )
 
 
@@ -1457,10 +1477,9 @@ class ReturnAlertForEditForm(BasePage):
         return errors.text.strip()
 
     def get_returned_banner_text(self):
-        element = self.wait_for_element(
-            ReturnForEditFormLocators.RETURN_FOR_EDIT_BANNER
-        )
-        return element.text.strip()
+        error_message = (By.CSS_SELECTOR, ".govuk-error-summary")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
 
 
 class AdminApprovalsPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1278,10 +1278,6 @@ class GovUkAlertsPage(BasePage):
 
     def get_alert_url(self, text):
         xpath = f"//div[div[p[contains(text(),'{text}')]]]//a[contains(text(),'More information')]"
-        xpath = (
-            By.XPATH,
-            f"//div[contains(@id,'template-list')]//a/span[contains(normalize-space(.), '{text}')]",
-        )
         element = self.wait_for_element(xpath)
         element.click()
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1276,10 +1276,10 @@ class GovUkAlertsPage(BasePage):
                 f'Could not find alert with extra content "{extra_content}"'
             )
 
-    def get_alert_url(self, text):
+    def get_alert_url(self, driver, text):
         xpath = f"//div[div[p[contains(text(),'{text}')]]]//a[contains(text(),'More information')]"
-        element = self.wait_for_element((xpath))
-        element.click()
+        link2 = driver.find_element(By.XPATH, value=xpath)
+        link2.click()
 
 
 class BroadcastDurationPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1277,8 +1277,12 @@ class GovUkAlertsPage(BasePage):
             )
 
     def get_alert_url(self, text):
-        xpath = f"""//div[p[contains(text(),'{text}')]]//a[contains(text(),'More information')]"""
-        element = self.wait_for_element((By.XPATH, xpath))
+        xpath = f"//div[div[p[contains(text(),'{text}')]]]//a[contains(text(),'More information')]"
+        xpath = (
+            By.XPATH,
+            f"//div[contains(@id,'template-list')]//a/span[contains(normalize-space(.), '{text}')]",
+        )
+        element = self.wait_for_element(xpath)
         element.click()
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import contextmanager
 from time import sleep
 
@@ -1263,6 +1264,7 @@ class GovUkAlertsPage(BasePage):
         delay=config["govuk_alerts_wait_retry_interval"],
     )
     def check_alert_is_published(self, driver, broadcast_content):
+        logging.info(driver.page_source)
         if broadcast_content not in driver.page_source:
             driver.refresh()
             raise RetryException(

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1278,7 +1278,7 @@ class GovUkAlertsPage(BasePage):
 
     def get_alert_url(self, text):
         xpath = f"//div[div[p[contains(text(),'{text}')]]]//a[contains(text(),'More information')]"
-        element = self.wait_for_element(xpath)
+        element = self.wait_for_element((xpath))
         element.click()
 
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1269,12 +1269,17 @@ class GovUkAlertsPage(BasePage):
                 f'Could not find alert with content "{broadcast_content}"'
             )
 
-    def check_extra_content_is_published(self, extra_content):
+    def check_extra_content_appears(self, extra_content):
         if not self.text_is_on_page(extra_content):
             self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with extra content "{extra_content}"'
             )
+
+    def get_alert_url(self, text):
+        xpath = f"""//div[p[contains(text(),'{text}')]]//a[contains(text(),'More information')]"""
+        element = self.wait_for_element((By.XPATH, xpath))
+        element.click()
 
 
 class BroadcastDurationPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1262,8 +1262,8 @@ class GovUkAlertsPage(BasePage):
         tries=config["govuk_alerts_wait_retry_times"],
         delay=config["govuk_alerts_wait_retry_interval"],
     )
-    def check_alert_is_published(self, broadcast_content):
-        if not self.text_is_on_page(broadcast_content):
+    def check_alert_is_published(self, driver, broadcast_content):
+        if broadcast_content not in driver.page_source:
             self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1262,31 +1262,19 @@ class GovUkAlertsPage(BasePage):
         tries=config["govuk_alerts_wait_retry_times"],
         delay=config["govuk_alerts_wait_retry_interval"],
     )
-    def check_alert_is_published(self, driver, broadcast_content):
-        if (
-            str(broadcast_content)
-            not in driver.find_element(by=By.TAG_NAME, value="p").text
-        ):
+    def check_alert_is_published(self, broadcast_content):
+        if not self.text_is_on_page(broadcast_content):
             self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
             )
 
-    def check_extra_content_appears(self, driver, extra_content):
-        if (
-            str(extra_content)
-            not in driver.find_element(by=By.TAG_NAME, value="p").text
-        ):
+    def check_extra_content_is_published(self, extra_content):
+        if not self.text_is_on_page(extra_content):
             self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with extra content "{extra_content}"'
             )
-
-    def get_alert_url(self, text):
-        xpath = f"""//p[contains(text(),'{text}')]/following-sibling::a[contains(text(),
-        'More information about this alert')]"""
-        element = self.wait_for_element((By.XPATH, xpath))
-        element.click()
 
 
 class BroadcastDurationPage(BasePage):

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1276,6 +1276,11 @@ class GovUkAlertsPage(BasePage):
                 f'Could not find alert with extra content "{extra_content}"'
             )
 
+    def find_alert_page(self, extra_content):
+        return self.driver.find_elements(
+            By.XPATH, f"//div[contains(text(), '{extra_content}')]//a"
+        ).get_attribute("href")
+
 
 class BroadcastDurationPage(BasePage):
     hours_input = HoursInputElement(name="hours")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1276,6 +1276,12 @@ class GovUkAlertsPage(BasePage):
                 f'Could not find alert with extra content "{extra_content}"'
             )
 
+    def get_alert_url(self, text):
+        xpath = f"""//div[p[contains(text(),'{text}')]]/following-sibling::a[contains(text(),
+        'More information about this alert')]"""
+        element = self.wait_for_element((By.XPATH, xpath))
+        element.click()
+
 
 class BroadcastDurationPage(BasePage):
     hours_input = HoursInputElement(name="hours")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1277,7 +1277,7 @@ class GovUkAlertsPage(BasePage):
             )
 
     def get_alert_url(self, text):
-        xpath = f"""//div[p[contains(text(),'{text}')]]/following-sibling::a[contains(text(),
+        xpath = f"""//p[contains(text(),'{text}')]/following-sibling::a[contains(text(),
         'More information about this alert')]"""
         element = self.wait_for_element((By.XPATH, xpath))
         element.click()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1264,14 +1264,14 @@ class GovUkAlertsPage(BasePage):
     )
     def check_alert_is_published(self, driver, broadcast_content):
         if broadcast_content not in driver.page_source:
-            self.driver.refresh()
+            driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
             )
 
-    def check_extra_content_appears(self, extra_content):
-        if not self.text_is_on_page(extra_content):
-            self.driver.refresh()
+    def check_extra_content_appears(self, driver, extra_content):
+        if extra_content not in driver.page_source:
+            driver.refresh()
             raise RetryException(
                 f'Could not find alert with extra content "{extra_content}"'
             )

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1,4 +1,3 @@
-import logging
 from contextlib import contextmanager
 from time import sleep
 
@@ -1264,16 +1263,21 @@ class GovUkAlertsPage(BasePage):
         delay=config["govuk_alerts_wait_retry_interval"],
     )
     def check_alert_is_published(self, driver, broadcast_content):
-        logging.info(driver.page_source)
-        if broadcast_content not in driver.page_source:
-            driver.refresh()
+        if (
+            str(broadcast_content)
+            not in driver.find_element(by=By.TAG_NAME, value="p").text
+        ):
+            self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with content "{broadcast_content}"'
             )
 
     def check_extra_content_appears(self, driver, extra_content):
-        if extra_content not in driver.page_source:
-            driver.refresh()
+        if (
+            str(extra_content)
+            not in driver.find_element(by=By.TAG_NAME, value="p").text
+        ):
+            self.driver.refresh()
             raise RetryException(
                 f'Could not find alert with extra content "{extra_content}"'
             )

--- a/tests/pages/rollups.py
+++ b/tests/pages/rollups.py
@@ -199,6 +199,11 @@ def create_alert(driver, id):
     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
     broadcast_freeform_page.click_continue()
 
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Countries")
     prepare_alert_pages.select_checkbox_or_radio(value="ctry19-E92000001")  # England

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,8 +229,7 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page.click_element_by_link_text(page_title)
     gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
-        gov_uk_alerts_page.get()
-        gov_uk_alerts_page.click_element_by_link_text("1 current alert")
+        gov_uk_alerts_page.get_alert_url(broadcast_content)
         gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,10 +227,9 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page = GovUkAlertsPage(driver)
     gov_uk_alerts_page.get()
     gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(driver, broadcast_content)
+    gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
-        gov_uk_alerts_page.get_alert_url(broadcast_content)
-        gov_uk_alerts_page.check_extra_content_appears(driver, extra_content)
+        gov_uk_alerts_page.check_extra_content_is_published(extra_content)
 
 
 def create_sign_in_url(email, url, next_redirect=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -221,11 +221,15 @@ def recordtime(func):
     return wrapper
 
 
-def check_alert_is_published_on_govuk_alerts(driver, page_title, broadcast_content):
+def check_alert_is_published_on_govuk_alerts(
+    driver, page_title, broadcast_content, extra_content=None
+):
     gov_uk_alerts_page = GovUkAlertsPage(driver)
     gov_uk_alerts_page.get()
     gov_uk_alerts_page.click_element_by_link_text(page_title)
     gov_uk_alerts_page.check_alert_is_published(broadcast_content)
+    if extra_content:
+        gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 
 def create_sign_in_url(email, url, next_redirect=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,6 +229,8 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page.click_element_by_link_text(page_title)
     gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
+        page_url = gov_uk_alerts_page.find_alert_page()
+        gov_uk_alerts_page.get(page_url)
         gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,7 +229,7 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page.click_element_by_link_text(page_title)
     gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
-        gov_uk_alerts_page.get_alert_url(broadcast_content)
+        gov_uk_alerts_page.get_alert_url(driver, broadcast_content)
         gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,10 +227,10 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page = GovUkAlertsPage(driver)
     gov_uk_alerts_page.get()
     gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(driver, broadcast_content)
+    gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
         gov_uk_alerts_page.get_alert_url(broadcast_content)
-        gov_uk_alerts_page.check_extra_content_appears(driver, extra_content)
+        gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 
 def create_sign_in_url(email, url, next_redirect=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,7 +230,7 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page.check_alert_is_published(driver, broadcast_content)
     if extra_content:
         gov_uk_alerts_page.get_alert_url(broadcast_content)
-        gov_uk_alerts_page.check_extra_content_appears(extra_content)
+        gov_uk_alerts_page.check_extra_content_appears(driver, extra_content)
 
 
 def create_sign_in_url(email, url, next_redirect=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,7 +227,7 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page = GovUkAlertsPage(driver)
     gov_uk_alerts_page.get()
     gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(broadcast_content)
+    gov_uk_alerts_page.check_alert_is_published(driver, broadcast_content)
     if extra_content:
         gov_uk_alerts_page.get_alert_url(broadcast_content)
         gov_uk_alerts_page.check_extra_content_appears(extra_content)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,8 +229,8 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page.click_element_by_link_text(page_title)
     gov_uk_alerts_page.check_alert_is_published(broadcast_content)
     if extra_content:
-        page_url = gov_uk_alerts_page.find_alert_page()
-        gov_uk_alerts_page.get(page_url)
+        gov_uk_alerts_page.get()
+        gov_uk_alerts_page.click_element_by_link_text("1 current alert")
         gov_uk_alerts_page.check_extra_content_appears(extra_content)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,9 +227,10 @@ def check_alert_is_published_on_govuk_alerts(
     gov_uk_alerts_page = GovUkAlertsPage(driver)
     gov_uk_alerts_page.get()
     gov_uk_alerts_page.click_element_by_link_text(page_title)
-    gov_uk_alerts_page.check_alert_is_published(broadcast_content)
+    gov_uk_alerts_page.check_alert_is_published(driver, broadcast_content)
     if extra_content:
-        gov_uk_alerts_page.check_extra_content_is_published(extra_content)
+        gov_uk_alerts_page.get_alert_url(broadcast_content)
+        gov_uk_alerts_page.check_extra_content_appears(driver, extra_content)
 
 
 def create_sign_in_url(email, url, next_redirect=None):


### PR DESCRIPTION
This PR consists of the following:
- Adjustment to `RejectionForm` to ensure that errors can be located, with `get_returned_banner_text` method, as banner has been adjusted in Admin application
- Adjustment to `check_alert_is_published_on_govuk_alerts`, so that if extra_content is passed in, the tests will click through to the specific alert page and assert that the extra content appears
- Adjustments made to other `test_broadcast_flow` tests, and `create_alert` rollup, to skip adding extra content
- Addition of relevant extra content elements, locators and methods for added ExtraContentPage