### PR TITLE
EAS-1732 Add REPPIR sites test

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,13 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
+      session-timeout
 
 phases:
   install:
@@ -45,7 +52,24 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          make test-cbc-integration; exit 0
+        else
+          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
+        fi
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          export testsuites="$testsuites cbc-integration"
+        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -52,24 +45,7 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          make test-cbc-integration; exit 0
-        else
-          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
-        fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
       - echo "Test run completed."
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          export testsuites="$testsuites cbc-integration"
-        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -389,23 +389,9 @@ def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
             "3km around the easting of 416567 and the northing of 432994 in Bradford",
         ),
         (
-            "easting_northing",
-            {
-                "first_coordinate": "419763",
-                "second_coordinate": "456038",
-                "radius": "5",
-            },
-            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-        ),
-        (
             "latitude_longitude",
             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
         ),
     ),
 )

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -488,6 +488,89 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
 
 
 @pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_REPPIR_site_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
+    prepare_alert_pages.select_checkbox_or_radio(
+        value="REPPIR_DEPZ_sites-awe_aldermaston"
+    )
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("	AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
 def test_reject_alert_with_reason(driver):
     sign_in(driver, account_type="broadcast_create_user")
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -526,7 +526,7 @@ def test_prepare_broadcast_with_REPPIR_site_content(driver):
 
     # check for selected areas and duration
     preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("	AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("AWE Aldermaston")
     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"


### PR DESCRIPTION
This PR adds a test that asserts that the REPPIR sites can be added to alerts successfully.
There's also the removal of the second set of params for existing tests, as no need to test exact same functionality again.