### PR TITLE
EAS-2645 Add areas to templates

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -31,7 +31,7 @@ phases:
       - apt-get install -yqq unzip jq
       - curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -rc '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64").url' > /tmp/chromedriver_url
       - wget -O /tmp/chromedriver.zip `cat /tmp/chromedriver_url`
-      - unzip -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
+      - unzip -o -j /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
       - apt-get install -f -y
 

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,13 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
+      session-timeout
 
 phases:
   install:
@@ -45,7 +52,24 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          make test-cbc-integration; exit 0
+        else
+          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
+        fi
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          export testsuites="$testsuites cbc-integration"
+        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -52,24 +45,7 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          make test-cbc-integration; exit 0
-        else
-          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
-        fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
       - echo "Test run completed."
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          export testsuites="$testsuites cbc-integration"
-        fi
         python3.12 ./scripts/report-test-results.py $(pwd) $testsuites
 
   post_build:

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -389,23 +389,9 @@ def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
             "3km around the easting of 416567 and the northing of 432994 in Bradford",
         ),
         (
-            "easting_northing",
-            {
-                "first_coordinate": "419763",
-                "second_coordinate": "456038",
-                "radius": "5",
-            },
-            "5km around the easting of 419763 and the northing of 456038 in North Yorkshire",
-        ),
-        (
             "latitude_longitude",
             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "54", "second_coordinate": "-1.7", "radius": "5"},
-            "5km around 54.0 latitude, -1.7 longitude in North Yorkshire",
         ),
     ),
 )

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -127,7 +127,7 @@ def test_prepare_broadcast_with_template(driver):
     go_to_templates_page(driver, service="broadcast_service")
     template_name = "test broadcast" + str(uuid.uuid4())
     content = "This is a test only."
-    create_broadcast_template(driver, name=template_name, content=content)
+    create_broadcast_template(driver, reference=template_name, content=content)
 
     current_alerts_page = CurrentAlertsPage(driver)
     current_alerts_page.go_to_service_landing_page(

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -488,6 +488,89 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
 
 
 @pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_REPPIR_site_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
+    prepare_alert_pages.select_checkbox_or_radio(
+        value="REPPIR_DEPZ_sites-awe_aldermaston"
+    )
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("	AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
 def test_reject_alert_with_reason(driver):
     sign_in(driver, account_type="broadcast_create_user")
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -526,7 +526,7 @@ def test_prepare_broadcast_with_REPPIR_site_content(driver):
 
     # check for selected areas and duration
     preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("	AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("AWE Aldermaston")
     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"

--- a/tests/functional/preview_and_dev/test_template_flow.py
+++ b/tests/functional/preview_and_dev/test_template_flow.py
@@ -166,11 +166,23 @@ def test_create_edit_and_delete_template(driver):
     assert edit_template.is_page_title("Template")
     assert edit_template.text_is_on_page(alert_name)
     assert edit_template.text_is_on_page(alert_content + extra_text)
-    # assert edit_template.text_is_on_page("less than a minute ago")
+    assert edit_template.text_is_on_page("less than a minute ago")
+
+    # Area added to template
+    edit_template.click_element_by_link_text("Add area")
+    choose_template_area_page = BasePage(driver)
+    choose_template_area_page.click_element_by_link_text("Local authorities")
+    choose_template_area_page.click_element_by_link_text("Adur")
+    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007564")
+    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007565")
+    choose_template_area_page.click_continue()
+    choose_template_area_page.click_element_by_link_text("Save and continue")
 
     edit_template.click_element_by_link_text("See previous versions")
     assert edit_template.text_is_on_page(alert_content)
     assert edit_template.text_is_on_page(alert_content + extra_text)
+    assert edit_template.text_is_on_page("Cokeham")
+    assert edit_template.text_is_on_page("Eastbrook")
 
     edit_template.click_element_by_link_text("Back to current templates")
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -85,6 +85,10 @@ class NameInputElement(ClearableInputElement):
     name = CommonPageLocators.NAME_INPUT[1]
 
 
+class ReferenceInputElement(ClearableInputElement):
+    name = CommonPageLocators.REFERENCE_INPUT[1]
+
+
 class FolderNameInputElement(ClearableInputElement):
     name = CommonPageLocators.FOLDER_NAME_INPUT[1]
 

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -85,6 +85,10 @@ class NameInputElement(ClearableInputElement):
     name = CommonPageLocators.NAME_INPUT[1]
 
 
+class FolderNameInputElement(ClearableInputElement):
+    name = CommonPageLocators.FOLDER_NAME_INPUT[1]
+
+
 class HoursInputElement(ClearableInputElement):
     name = DurationPageLocators.HOURS_INPUT[1]
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -2,7 +2,8 @@ from selenium.webdriver.common.by import By
 
 
 class CommonPageLocators(object):
-    NAME_INPUT = (By.NAME, "name")
+    NAME_INPUT = (By.NAME, "reference")
+    FOLDER_NAME_INPUT = (By.NAME, "name")
     EMAIL_INPUT = (By.NAME, "email_address")
     PASSWORD_INPUT = (By.NAME, "password")
     MOBILE_NUMBER = (By.NAME, "mobile_number")
@@ -73,11 +74,11 @@ class TemplatePageLocators(object):
 
 class EditTemplatePageLocators(object):
     TEMPLATE_SUBJECT_INPUT = (By.NAME, "subject")
-    TEMPLATE_CONTENT_INPUT = (By.NAME, "template_content")
+    TEMPLATE_CONTENT_INPUT = (By.NAME, "content")
     SAVE_BUTTON = (By.CSS_SELECTOR, "main button.govuk-button")
     EDIT_BUTTON = (
         By.XPATH,
-        "//a[contains(@class, 'govuk-link') and contains(text(),'Edit')]",
+        "//a[contains(@class, 'govuk-link') and contains(text(),'Change')]",
     )
     PREP_TO_SEND_BUTTON = (
         By.XPATH,

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -2,7 +2,8 @@ from selenium.webdriver.common.by import By
 
 
 class CommonPageLocators(object):
-    NAME_INPUT = (By.NAME, "reference")
+    NAME_INPUT = (By.NAME, "name")
+    REFERENCE_INPUT = (By.NAME, "reference")
     FOLDER_NAME_INPUT = (By.NAME, "name")
     EMAIL_INPUT = (By.NAME, "email_address")
     PASSWORD_INPUT = (By.NAME, "password")

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -26,6 +26,7 @@ from tests.pages.element import (
     ExtraContentElement,
     FeedbackTextAreaElement,
     FirstCoordinateInputElement,
+    FolderNameInputElement,
     HoursInputElement,
     InactivityDialog,
     InactivityDialogStaySignedInButton,
@@ -688,6 +689,10 @@ class ShowTemplatesPage(PageWithStickyNavMixin, BasePage):
             return None
 
 
+class ChooseTemplateFieldsPage(BasePage):
+    pass
+
+
 class SendSmsTemplatePage(BasePage):
     new_sms_template_link = TemplatePageLocators.ADD_NEW_TEMPLATE_LINK
     edit_sms_template_link = TemplatePageLocators.EDIT_TEMPLATE_LINK
@@ -715,8 +720,8 @@ class EditBroadcastTemplatePage(BasePage):
             ),
         )
 
-    def create_template(self, name="Template Name", content=None):
-        self.name_input = name
+    def create_template(self, reference="Template Name", content=None):
+        self.name_input = reference
         if content:
             self.template_content_input = content
         else:
@@ -1209,6 +1214,7 @@ class ViewFolderPage(ShowTemplatesPage):
 class ManageFolderPage(BasePage):
     delete_link = (By.LINK_TEXT, "Delete this folder")
     name_input = NameInputElement()
+    folder_name_input = FolderNameInputElement()
     delete_button = (By.NAME, "delete")
     save_button = (
         By.CSS_SELECTOR,
@@ -1216,7 +1222,7 @@ class ManageFolderPage(BasePage):
     )
 
     def set_name(self, new_name):
-        self.name_input = new_name
+        self.folder_name_input = new_name
         button = self.wait_for_element(self.save_button)
         button.click()
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -39,6 +39,7 @@ from tests.pages.element import (
     PostcodeInputElement,
     PreviewButton,
     RadiusInputElement,
+    ReferenceInputElement,
     RejectAlertButton,
     RejectionDetailElement,
     RejectionDetailLink,
@@ -703,7 +704,7 @@ class SendSmsTemplatePage(BasePage):
 
 
 class EditBroadcastTemplatePage(BasePage):
-    name_input = NameInputElement()
+    reference_input = ReferenceInputElement()
     template_content_input = TemplateContentElement()
     save_button = EditTemplatePageLocators.SAVE_BUTTON
     edit_button = EditTemplatePageLocators.EDIT_BUTTON
@@ -721,7 +722,7 @@ class EditBroadcastTemplatePage(BasePage):
         )
 
     def create_template(self, reference="Template Name", content=None):
-        self.name_input = reference
+        self.reference_input = reference
         if content:
             self.template_content_input = content
         else:
@@ -776,7 +777,7 @@ class ViewTemplatePage(BasePage):
 
 
 class EditEmailTemplatePage(BasePage):
-    name_input = NameInputElement()
+    reference_input = ReferenceInputElement()
     subject_input = SubjectInputElement()
     template_content_input = TemplateContentElement()
     save_button = EditTemplatePageLocators.SAVE_BUTTON
@@ -803,7 +804,7 @@ class EditEmailTemplatePage(BasePage):
         element.click()
 
     def create_template(self, name="Test email template", content=None):
-        self.name_input = name
+        self.reference_input = name
         self.subject_input = "Test email from functional tests"
         if content:
             self.template_content_input = content

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -1237,7 +1237,7 @@ class ManageFolderPage(BasePage):
 
 
 class BroadcastFreeformPage(BasePage):
-    title_input = NameInputElement()
+    title_input = ReferenceInputElement()
     content_input = TemplateContentElement()
 
     def create_broadcast_content(self, title, content):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from tests.pages import (
     ShowTemplatesPage,
     VerifyPage,
 )
+from tests.pages.pages import ChooseTemplateFieldsPage
 
 logging.basicConfig(
     filename="./logs/test_run_{}.log".format(datetime.now(timezone.utc)),
@@ -132,12 +133,17 @@ def do_email_verification(driver, template_id, email_address):
         return True
 
 
-def create_broadcast_template(driver, name="test template", content=None):
+def create_broadcast_template(driver, reference="test template", content=None):
     show_templates_page = ShowTemplatesPage(driver)
     show_templates_page.click_add_new_template()
 
+    choose_template_fields_page = ChooseTemplateFieldsPage(driver)
+    # Selects checkbox for creating template with only content
+    choose_template_fields_page.select_checkbox_or_radio(value="content_only")
+    choose_template_fields_page.click_continue()
+
     template_page = EditBroadcastTemplatePage(driver)
-    template_page.create_template(reference=name, content=content)
+    template_page.create_template(reference=reference, content=content)
     return template_page.get_template_id()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,7 +137,7 @@ def create_broadcast_template(driver, name="test template", content=None):
     show_templates_page.click_add_new_template()
 
     template_page = EditBroadcastTemplatePage(driver)
-    template_page.create_template(name=name, content=content)
+    template_page.create_template(reference=name, content=content)
     return template_page.get_template_id()
 
 


### PR DESCRIPTION
This PR consists of adjustments to existing Template-related tests, to account for the changes made in [Admin PR](https://github.com/alphagov/emergency-alerts-admin/pull/268) and adds tests for asserting the new functionality behaves correctly.