### PR TITLE
EAS-2416 Add test for Flood Warning areas

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -22,6 +22,7 @@ from tests.pages.pages import (
     ExtraContentPage,
     RejectionForm,
     ReturnAlertForEditForm,
+    SearchFloodWarningAreaPage,
     SearchPostcodePage,
 )
 from tests.pages.rollups import sign_in
@@ -488,7 +489,7 @@ def test_prepare_broadcast_with_new_content_for_coordinate_area(
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_REPPIR_site_content(driver):
+def test_prepare_broadcast_with_REPPIR_site(driver):
     sign_in(driver, account_type="broadcast_create_user")
 
     # prepare alert
@@ -527,6 +528,101 @@ def test_prepare_broadcast_with_REPPIR_site_content(driver):
     # check for selected areas and duration
     preview_alert_page = BasePage(driver)
     assert preview_alert_page.text_is_on_page("AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_flood_warning_target_area(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text(
+        "Flood Warning Target Areas (TA code)"
+    )
+
+    # Enter TA code and click 'Add area' button to add area to alert
+    search_flood_warning_area_page = SearchFloodWarningAreaPage(driver)
+    TA_code = "122FWB112"
+
+    search_flood_warning_area_page.create_ta_code_input(TA_code)
+    search_flood_warning_area_page.click_add_area()
+
+    assert search_flood_warning_area_page.text_is_on_page(
+        "122FWB112: Hull city centre"
+    )  # Area has been returned and displayed correctly
+
+    search_flood_warning_area_page.click_element_by_link_text(
+        "Save and continue to preview"
+    )
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Hull city centre")
     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -14,6 +14,7 @@ from tests.pages.locators import (
     RejectionFormLocators,
     ReturnForEditFormLocators,
     SearchCoordinatePageLocators,
+    SearchFloodWarningAreaPageLocators,
     SearchPostcodePageLocators,
     SignUpPageLocators,
     SupportPageLocators,
@@ -203,3 +204,11 @@ class RejectionDetailLink:
 
 class ReturnForEditReasonTextArea(BasePageElement):
     name = ReturnForEditFormLocators.RETURN_FOR_EDIT_REASON_TEXTAREA[1]
+
+
+class FloodWarningAreaCodeInputElement(BasePageElement):
+    name = SearchFloodWarningAreaPageLocators.TA_CODE_INPUT[1]
+
+
+class AddAreaButton(BasePageElement):
+    name = SearchFloodWarningAreaPageLocators.ADD_AREA_BUTTON[1]

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -188,7 +188,7 @@ class SearchCoordinatePageLocators(object):
 
 
 class SearchFloodWarningAreaPageLocators(object):
-    TA_CODE_INPUT = (By.ID, "second_coordinate")
+    TA_CODE_INPUT = (By.NAME, "flood_warning_area")
     ADD_AREA_BUTTON = (By.NAME, "add_area_button")
 
 

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -187,6 +187,11 @@ class SearchCoordinatePageLocators(object):
     PREVIEW_BUTTON = (By.NAME, "preview")
 
 
+class SearchFloodWarningAreaPageLocators(object):
+    TA_CODE_INPUT = (By.ID, "second_coordinate")
+    ADD_AREA_BUTTON = (By.NAME, "add_area_button")
+
+
 class PlatformAdminPageLocators(object):
     SEARCH_INPUT = (By.NAME, "search")
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -26,6 +26,7 @@ from tests.pages.element import (
     ExtraContentElement,
     FeedbackTextAreaElement,
     FirstCoordinateInputElement,
+    FloodWarningAreaCodeInputElement,
     FolderNameInputElement,
     HoursInputElement,
     InactivityDialog,
@@ -69,6 +70,7 @@ from tests.pages.locators import (
     RejectionFormLocators,
     ReturnForEditFormLocators,
     SearchCoordinatePageLocators,
+    SearchFloodWarningAreaPageLocators,
     SearchPostcodePageLocators,
     ServiceSettingsLocators,
     SignInPageLocators,
@@ -1369,6 +1371,19 @@ class ChooseCoordinateArea(BasePage):
 
     def click_preview(self):
         element = self.wait_for_element(SearchCoordinatePageLocators.PREVIEW_BUTTON)
+        element.click()
+
+
+class SearchFloodWarningAreaPage(BasePage):
+    ta_code_input = FloodWarningAreaCodeInputElement()
+
+    def create_ta_code_input(self, ta_code):
+        self.ta_code_input = ta_code
+
+    def click_add_area(self):
+        element = self.wait_for_element(
+            SearchFloodWarningAreaPageLocators.ADD_AREA_BUTTON
+        )
         element.click()
 
 


### PR DESCRIPTION
This PR adds a functional test asserting that the functionality, involved in adding a flood warning area to an alert, behaves correctly. Necessary locators, elements and pages have also been added.