### PR TITLE
EAS-2834 Handling invalid area

### DIFF
--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,13 +4,6 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
-      platform-admin-flow
-      authentication-flow
-      links-and-cookies
-      template-flow
-      user-operations
-      throttling
-      session-timeout
 
 phases:
   install:
@@ -52,19 +45,6 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
-      - |
-        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
-          make test-cbc-integration; exit 0
-        else
-          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
-        fi
-      - make test-platform-admin-flow; exit 0
-      - make test-authentication-flow; exit 0
-      - make test-links-and-cookies; exit 0
-      - make test-template-flow; exit 0
-      - make test-user-operations; exit 0
-      - make test-throttling; exit 0
-      - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/.codepipeline/buildspec-tests-build.yml
+++ b/.codepipeline/buildspec-tests-build.yml
@@ -4,6 +4,13 @@ env:
   variables:
     testsuites: >-
       broadcast-flow
+      platform-admin-flow
+      authentication-flow
+      links-and-cookies
+      template-flow
+      user-operations
+      throttling
+      session-timeout
 
 phases:
   install:
@@ -45,6 +52,19 @@ phases:
       # Need to add CBC integration into the list of test reports, in the proper place, if it is executed - hence the below
       # The if below doesn't check for truthiness, but instead "true", because CodePipeline *requires* a value - therefore it will *always* be truthy.
       - make test-broadcast-flow; exit 0
+      - |
+        if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then
+          make test-cbc-integration; exit 0
+        else
+          echo "SKIPPING WORKFLOW 'test-cbc-integration'..."
+        fi
+      - make test-platform-admin-flow; exit 0
+      - make test-authentication-flow; exit 0
+      - make test-links-and-cookies; exit 0
+      - make test-template-flow; exit 0
+      - make test-user-operations; exit 0
+      - make test-throttling; exit 0
+      - make test-session-timeout; exit 0
       - echo "Test run completed."
       - |
         if [ "$ENABLE_CBC_INTEGRATION_TESTS" = "true" ]; then

--- a/tests/functional/preview_and_dev/sample_cap_xml.py
+++ b/tests/functional/preview_and_dev/sample_cap_xml.py
@@ -59,3 +59,36 @@ CANCEL_XML = """
         </info>
     </alert>
 """
+
+INVALID_AREA_ALERT_XML = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+        <identifier>{identifier}</identifier>
+        <sender>www.gov.uk/environment-agency</sender>
+        <sent>{alert_sent}</sent>
+        <status>Actual</status>
+        <msgType>Alert</msgType>
+        <scope>Public</scope>
+        <info>
+            <language>en-GB</language>
+            <category>Met</category>
+            <event>{event}</event>
+            <urgency>Immediate</urgency>
+            <severity>Severe</severity>
+            <certainty>Likely</certainty>
+            <expires>2022-06-15T12:12:13-00:00</expires>
+            <senderName>Environment Agency</senderName>
+            <description>{broadcast_content}</description>
+            <instruction>Check the latest information for your area. </instruction>
+            <area>
+                <areaDesc>Invalid Area</areaDesc>
+                <polygon>55.730267,-4.908142 55.730267,-4.567566 55.609448,-4.562073 55.257272,-4.858704 55.01864,-5.270691 54.987135,-4.858704 55.360445,-4.858704 55.347953,-4.864197 55.347953,-4.908142 55.730267,-4.908142</polygon>
+                <geocode>
+                <valueName>TargetAreaCode</valueName>
+                <value>
+                    <![CDATA[InvalidArea]]>
+                </value>
+            </geocode>
+            </area>
+        </info>
+    </alert>
+"""

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -288,14 +288,14 @@ def test_create_broadcast_with_invalid_area_then_discard(driver, broadcast_clien
 
     # Asserts that error message appears on page
     assert page.get_errors_from_error_summary() == (
-        "The area used is invalid and the alert cannot be sent. "
+        "There is a problem\nThe area used is invalid and the alert cannot be sent. "
         "If the alert was created through the API, report it to the alert creator. "
         "Otherwise report it to the Emergency Alerts team."
     )
 
     page.click_element_by_link_text("Discard this alert")
 
-    time.sleep(10)
+    time.sleep(5)
     page.click_element_by_link_text("Rejected alerts")
     assert page.text_is_on_page(event)
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -4,287 +4,264 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from config import config
 from tests.functional.preview_and_dev.sample_cap_xml import (
-    ALERT_XML,
-    CANCEL_XML,
     INVALID_AREA_ALERT_XML,
 )
-from tests.pages import (
-    BasePage,
-    BroadcastDurationPage,
-    BroadcastFreeformPage,
-    CurrentAlertsPage,
-    ShowTemplatesPage,
-)
-from tests.pages.pages import (
-    ChooseCoordinateArea,
-    ChooseCoordinatesType,
-    ExtraContentPage,
-    RejectionForm,
-    ReturnAlertForEditForm,
-    SearchPostcodePage,
-)
+from tests.pages import BasePage
 from tests.pages.rollups import sign_in
-from tests.test_utils import (
-    check_alert_is_published_on_govuk_alerts,
-    convert_naive_utc_datetime_to_cap_standard_string,
-    create_broadcast_template,
-    delete_template,
-    go_to_templates_page,
-)
+from tests.test_utils import convert_naive_utc_datetime_to_cap_standard_string
 
 test_group_name = "broadcast-flow"
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
 
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast " + test_uuid
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast " + test_uuid
 
-    current_alerts_page.click_element_by_link_text("Create new alert")
+#     current_alerts_page.click_element_by_link_text("Create new alert")
 
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
 
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
 
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
 
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
 
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
 
-    preview_alert_page.sign_out()
+#     preview_alert_page.sign_out()
 
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
 
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
 
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_template(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    go_to_templates_page(driver, service="broadcast_service")
-    template_name = "test broadcast" + str(uuid.uuid4())
-    content = "This is a test only."
-    create_broadcast_template(driver, reference=template_name, content=content)
-
-    current_alerts_page = CurrentAlertsPage(driver)
-    current_alerts_page.go_to_service_landing_page(
-        service_id=config["broadcast_service"]["id"]
-    )
-    current_alerts_page.click_element_by_link_text("Current alerts")
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="template")
-    new_alert_page.click_continue()
-
-    templates_page = ShowTemplatesPage(driver)
-    templates_page.click_template_by_link_text(template_name)
-
-    templates_page.click_element_by_link_text("Save and get ready to send")
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert prepare_alert_pages.text_is_on_page("Cokeham")
-    assert prepare_alert_pages.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
-    assert prepare_alert_pages.text_is_on_page(
-        f"{template_name} is waiting for approval"
-    )
-
-    prepare_alert_pages.click_element_by_link_text("Discard this alert")
-    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.text_is_on_page(template_name)
-
-    delete_template(driver, template_name, service="broadcast_service")
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc) - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc)
-    )
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_template(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
 
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
+#     go_to_templates_page(driver, service="broadcast_service")
+#     template_name = "test broadcast" + str(uuid.uuid4())
+#     content = "This is a test only."
+#     create_broadcast_template(driver, reference=template_name, content=content)
 
-    sign_in(driver, account_type="broadcast_approve_user")
-    page = BasePage(driver)
-    page.click_element_by_link_text(event)
+#     current_alerts_page = CurrentAlertsPage(driver)
+#     current_alerts_page.go_to_service_landing_page(
+#         service_id=config["broadcast_service"]["id"]
+#     )
+#     current_alerts_page.click_element_by_link_text("Current alerts")
+#     current_alerts_page.click_element_by_link_text("Create new alert")
 
-    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="template")
+#     new_alert_page.click_continue()
 
-    reject_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(reject_broadcast_xml)
+#     templates_page = ShowTemplatesPage(driver)
+#     templates_page.click_template_by_link_text(template_name)
 
-    time.sleep(10)
-    page.click_element_by_link_text("Rejected alerts")
-    assert page.text_is_on_page(event)
+#     templates_page.click_element_by_link_text("Save and get ready to send")
 
-    page.get()
-    page.sign_out()
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert prepare_alert_pages.text_is_on_page("Cokeham")
+#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
+#     assert prepare_alert_pages.text_is_on_page(
+#         f"{template_name} is waiting for approval"
+#     )
+
+#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
+#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.text_is_on_page(template_name)
+
+#     delete_template(driver, template_name, service="broadcast_service")
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc) - timedelta(hours=1)
-    )
-    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-        datetime.now(timezone.utc)
-    )
-    identifier = uuid.uuid4()
-    event = f"test broadcast {identifier}"
-    broadcast_content = f"Flood warning {identifier} has been issued"
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc) - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc)
+#     )
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
 
-    new_alert_xml = ALERT_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        event=event,
-        broadcast_content=broadcast_content,
-    )
-    broadcast_client.post_broadcast_data(new_alert_xml)
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
 
-    sign_in(driver, account_type="broadcast_approve_user")
+#     sign_in(driver, account_type="broadcast_approve_user")
+#     page = BasePage(driver)
+#     page.click_element_by_link_text(event)
 
-    page = BasePage(driver)
-    page.click_element_by_link_text(event)
-    page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    page.click_submit()
+#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
 
-    assert page.text_is_on_page("since today at")
+#     reject_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
 
-    alert_page_url = page.current_url
+#     time.sleep(10)
+#     page.click_element_by_link_text("Rejected alerts")
+#     assert page.text_is_on_page(event)
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
+#     page.get()
+#     page.sign_out()
 
-    cancel_broadcast_xml = CANCEL_XML.format(
-        identifier=identifier,
-        alert_sent=sent_time,
-        cancel_sent=cancel_time,
-        event=event,
-    )
-    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-    # go back to the page for the current alert
-    time.sleep(10)
-    page.get(alert_page_url)
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc) - timedelta(hours=1)
+#     )
+#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+#         datetime.now(timezone.utc)
+#     )
+#     identifier = uuid.uuid4()
+#     event = f"test broadcast {identifier}"
+#     broadcast_content = f"Flood warning {identifier} has been issued"
 
-    # assert that it's now cancelled
-    assert page.text_is_on_page("Stopped by an API call")
-    page.click_element_by_link_text("Past alerts")
-    assert page.text_is_on_page(event)
+#     new_alert_xml = ALERT_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         event=event,
+#         broadcast_content=broadcast_content,
+#     )
+#     broadcast_client.post_broadcast_data(new_alert_xml)
 
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+#     sign_in(driver, account_type="broadcast_approve_user")
 
-    page.get()
-    page.sign_out()
+#     page = BasePage(driver)
+#     page.click_element_by_link_text(event)
+#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     page.click_submit()
+
+#     assert page.text_is_on_page("since today at")
+
+#     alert_page_url = page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     cancel_broadcast_xml = CANCEL_XML.format(
+#         identifier=identifier,
+#         alert_sent=sent_time,
+#         cancel_sent=cancel_time,
+#         event=event,
+#     )
+#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+#     # go back to the page for the current alert
+#     time.sleep(10)
+#     page.get(alert_page_url)
+
+#     # assert that it's now cancelled
+#     assert page.text_is_on_page("Stopped by an API call")
+#     page.click_element_by_link_text("Past alerts")
+#     assert page.text_is_on_page(event)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     page.get()
+#     page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)
@@ -328,553 +305,553 @@ def test_create_broadcast_with_invalid_area_then_discard(driver, broadcast_clien
     page.sign_out()
 
 
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast" + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Postcode areas")
-    # This is where it varies
-    search_postcode_page = SearchPostcodePage(driver)
-    postcode_to_search = "BD1 1EE"
-    radius_to_add = "5"
-    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-    search_postcode_page.click_search()
-    # assert areas appear here
-
-    search_postcode_page.click_continue()
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # here check if selected areas displayed
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page(
-        "5km around the postcode BD1 1EE in Bradford"
-    )
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-@pytest.mark.parametrize(
-    "coordinate_type, post_data, expected_area_description",
-    (
-        (
-            "easting_northing",
-            {
-                "first_coordinate": "416567",
-                "second_coordinate": "432994",
-                "radius": "3",
-            },
-            "3km around the easting of 416567 and the northing of 432994 in Bradford",
-        ),
-        (
-            "latitude_longitude",
-            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-            "3km around 53.793 latitude, -1.75 longitude in Bradford",
-        ),
-    ),
-)
-def test_prepare_broadcast_with_new_content_for_coordinate_area(
-    driver, coordinate_type, post_data, expected_area_description
-):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast{test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Coordinates")
-    # This is where it varies
-    choose_type_page = ChooseCoordinatesType(driver)
-    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-    choose_type_page.click_continue()
-
-    choose_coordinate_area_page = ChooseCoordinateArea(driver)
-    choose_coordinate_area_page.create_coordinate_area(
-        post_data["first_coordinate"],
-        post_data["second_coordinate"],
-        post_data["radius"],
-    )
-    choose_coordinate_area_page.click_search()
-    choose_coordinate_area_page.click_continue()
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # here check if selected areas displayed
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page(expected_area_description)
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_REPPIR_site_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast " + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
-    prepare_alert_pages.select_checkbox_or_radio(
-        value="REPPIR_DEPZ_sites-awe_aldermaston"
-    )
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("AWE Aldermaston")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_reject_alert_with_reason(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast {test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # reject the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-    alert_page_with_rejection = RejectionForm(driver)
-    assert alert_page_with_rejection.rejection_details_is_closed()
-    alert_page_with_rejection.click_open_reject_detail()
-    assert alert_page_with_rejection.rejection_details_is_open()
-
-    # Without rejection reason
-    rejection_reason = ""
-    alert_page_with_rejection.click_reject_alert()
-
-    # Assert errors appear
-    assert (
-        alert_page_with_rejection.get_rejection_form_errors()
-        == "Error:\nEnter the reason for rejecting the alert"
-    )
-
-    # With rejection reason
-    rejection_reason = "This is a test rejection reason."
-    alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
-    alert_page_with_rejection.click_reject_alert()
-
-    assert current_alerts_page.text_is_on_page("Current alerts")
-    current_alerts_page.click_element_by_link_text("Rejected alerts")
-
-    rejected_alerts_page = BasePage(driver)
-    assert rejected_alerts_page.text_is_on_page(broadcast_title)
-    assert rejected_alerts_page.text_is_on_page(rejection_reason)
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_return_alert_for_edit(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = f"test broadcast {test_uuid}"
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = f"This is a test broadcast {test_uuid}"
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing not to add extra_content
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="no")
-    choose_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Local authorities")
-    prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Cokeham")
-    assert preview_alert_page.text_is_on_page("Eastbrook")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # Return the alert for edit
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-    alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
-    assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
-    alert_page_with_return_for_edit.click_open_return_for_edit_detail()
-    assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
-
-    # Without rejection reason
-    reason_for_returning_alert = ""
-    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-        reason_for_returning_alert
-    )
-    alert_page_with_return_for_edit.click_return_alert_for_edit()
-
-    # Assert errors appear
-    assert (
-        alert_page_with_return_for_edit.get_return_for_edit_form_errors()
-        == "Error:\nEnter the reason for returning the alert for edit"
-    )
-
-    # With reason for returning alert for edit
-    reason_for_returning_alert = (
-        "This is a test reason for returning the alert for edit."
-    )
-    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-        reason_for_returning_alert
-    )
-    alert_page_with_return_for_edit.click_return_alert_for_edit()
-    assert (
-        f"This alert has been returned to edit, because: {reason_for_returning_alert}"
-        in alert_page_with_return_for_edit.get_returned_banner_text()
-    )
-    assert alert_page_with_return_for_edit.text_is_on_page(
-        "Submitted by Functional Tests - Broadcast User Create"
-    )
-    assert alert_page_with_return_for_edit.text_is_on_page(
-        "Returned by Functional Tests - Broadcast User Approve"
-    )
-
-    assert current_alerts_page.text_is_on_page("Current alerts")
-    assert current_alerts_page.text_is_on_page(broadcast_title)
-
-
-@pytest.mark.xdist_group(name=test_group_name)
-def test_prepare_broadcast_with_extra_content(driver):
-    sign_in(driver, account_type="broadcast_create_user")
-
-    # prepare alert
-    current_alerts_page = BasePage(driver)
-    test_uuid = str(uuid.uuid4())
-    broadcast_title = "test broadcast " + test_uuid
-
-    current_alerts_page.click_element_by_link_text("Create new alert")
-
-    new_alert_page = BasePage(driver)
-    new_alert_page.select_checkbox_or_radio(value="freeform")
-    new_alert_page.click_continue()
-
-    broadcast_freeform_page = BroadcastFreeformPage(driver)
-    broadcast_content = "This is a test broadcast " + test_uuid
-    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-    broadcast_freeform_page.click_continue()
-
-    # Choosing to add exra_content to alert
-    choose_extra_content_page = BasePage(driver)
-    choose_extra_content_page.select_checkbox_or_radio(value="yes")
-    choose_extra_content_page.click_continue()
-
-    # Adding extra_content to textarea and submitting
-    add_extra_content_page = ExtraContentPage(driver)
-    extra_content = "This is extra content " + test_uuid
-    add_extra_content_page.create_extra_content(extra_content)
-    add_extra_content_page.click_continue()
-
-    prepare_alert_pages = BasePage(driver)
-    prepare_alert_pages.click_element_by_link_text("Countries")
-    prepare_alert_pages.select_checkbox_or_radio(value="ctry19-W92000004")
-    prepare_alert_pages.click_continue()
-    prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-    broadcast_duration_page = BroadcastDurationPage(driver)
-    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-    broadcast_duration_page.click_preview()  # Preview alert
-
-    # check for selected areas and duration
-    preview_alert_page = BasePage(driver)
-    assert preview_alert_page.text_is_on_page("Wales")
-    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-    assert preview_alert_page.text_is_on_page(
-        f"{broadcast_title} is waiting for approval"
-    )
-
-    preview_alert_page.sign_out()
-
-    # approve the alert
-    sign_in(driver, account_type="broadcast_approve_user")
-
-    current_alerts_page.click_element_by_link_text(broadcast_title)
-    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-    current_alerts_page.click_submit()
-    assert current_alerts_page.text_is_on_page("since today at")
-    alert_page_url = current_alerts_page.current_url
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Current alerts", broadcast_content
-    )
-
-    # get back to the alert page
-    current_alerts_page.get(alert_page_url)
-
-    # stop sending the alert
-    current_alerts_page.click_element_by_link_text("Stop sending")
-    current_alerts_page.click_submit()  # stop broadcasting
-    assert current_alerts_page.text_is_on_page(
-        "Stopped by Functional Tests - Broadcast User Approve"
-    )
-    current_alerts_page.click_element_by_link_text("Past alerts")
-    past_alerts_page = BasePage(driver)
-    assert past_alerts_page.text_is_on_page(broadcast_title)
-
-    time.sleep(10)
-    check_alert_is_published_on_govuk_alerts(
-        driver, "Past alerts", broadcast_content, extra_content
-    )
-
-    current_alerts_page.get()
-    current_alerts_page.sign_out()
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast" + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
+#     # This is where it varies
+#     search_postcode_page = SearchPostcodePage(driver)
+#     postcode_to_search = "BD1 1EE"
+#     radius_to_add = "5"
+#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+#     search_postcode_page.click_search()
+#     # assert areas appear here
+
+#     search_postcode_page.click_continue()
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # here check if selected areas displayed
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page(
+#         "5km around the postcode BD1 1EE in Bradford"
+#     )
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# @pytest.mark.parametrize(
+#     "coordinate_type, post_data, expected_area_description",
+#     (
+#         (
+#             "easting_northing",
+#             {
+#                 "first_coordinate": "416567",
+#                 "second_coordinate": "432994",
+#                 "radius": "3",
+#             },
+#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
+#         ),
+#         (
+#             "latitude_longitude",
+#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
+#         ),
+#     ),
+# )
+# def test_prepare_broadcast_with_new_content_for_coordinate_area(
+#     driver, coordinate_type, post_data, expected_area_description
+# ):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast{test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Coordinates")
+#     # This is where it varies
+#     choose_type_page = ChooseCoordinatesType(driver)
+#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+#     choose_type_page.click_continue()
+
+#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
+#     choose_coordinate_area_page.create_coordinate_area(
+#         post_data["first_coordinate"],
+#         post_data["second_coordinate"],
+#         post_data["radius"],
+#     )
+#     choose_coordinate_area_page.click_search()
+#     choose_coordinate_area_page.click_continue()
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # here check if selected areas displayed
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page(expected_area_description)
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_REPPIR_site_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast " + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
+#     prepare_alert_pages.select_checkbox_or_radio(
+#         value="REPPIR_DEPZ_sites-awe_aldermaston"
+#     )
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("AWE Aldermaston")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_reject_alert_with_reason(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast {test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # reject the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+#     alert_page_with_rejection = RejectionForm(driver)
+#     assert alert_page_with_rejection.rejection_details_is_closed()
+#     alert_page_with_rejection.click_open_reject_detail()
+#     assert alert_page_with_rejection.rejection_details_is_open()
+
+#     # Without rejection reason
+#     rejection_reason = ""
+#     alert_page_with_rejection.click_reject_alert()
+
+#     # Assert errors appear
+#     assert (
+#         alert_page_with_rejection.get_rejection_form_errors()
+#         == "Error:\nEnter the reason for rejecting the alert"
+#     )
+
+#     # With rejection reason
+#     rejection_reason = "This is a test rejection reason."
+#     alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
+#     alert_page_with_rejection.click_reject_alert()
+
+#     assert current_alerts_page.text_is_on_page("Current alerts")
+#     current_alerts_page.click_element_by_link_text("Rejected alerts")
+
+#     rejected_alerts_page = BasePage(driver)
+#     assert rejected_alerts_page.text_is_on_page(broadcast_title)
+#     assert rejected_alerts_page.text_is_on_page(rejection_reason)
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_return_alert_for_edit(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = f"test broadcast {test_uuid}"
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = f"This is a test broadcast {test_uuid}"
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing not to add extra_content
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="no")
+#     choose_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Local authorities")
+#     prepare_alert_pages.click_element_by_link_text("Adur")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Cokeham")
+#     assert preview_alert_page.text_is_on_page("Eastbrook")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # Return the alert for edit
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+#     alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
+#     assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
+#     alert_page_with_return_for_edit.click_open_return_for_edit_detail()
+#     assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
+
+#     # Without rejection reason
+#     reason_for_returning_alert = ""
+#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+#         reason_for_returning_alert
+#     )
+#     alert_page_with_return_for_edit.click_return_alert_for_edit()
+
+#     # Assert errors appear
+#     assert (
+#         alert_page_with_return_for_edit.get_return_for_edit_form_errors()
+#         == "Error:\nEnter the reason for returning the alert for edit"
+#     )
+
+#     # With reason for returning alert for edit
+#     reason_for_returning_alert = (
+#         "This is a test reason for returning the alert for edit."
+#     )
+#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+#         reason_for_returning_alert
+#     )
+#     alert_page_with_return_for_edit.click_return_alert_for_edit()
+#     assert (
+#         f"This alert has been returned to edit, because: {reason_for_returning_alert}"
+#         in alert_page_with_return_for_edit.get_returned_banner_text()
+#     )
+#     assert alert_page_with_return_for_edit.text_is_on_page(
+#         "Submitted by Functional Tests - Broadcast User Create"
+#     )
+#     assert alert_page_with_return_for_edit.text_is_on_page(
+#         "Returned by Functional Tests - Broadcast User Approve"
+#     )
+
+#     assert current_alerts_page.text_is_on_page("Current alerts")
+#     assert current_alerts_page.text_is_on_page(broadcast_title)
+
+
+# @pytest.mark.xdist_group(name=test_group_name)
+# def test_prepare_broadcast_with_extra_content(driver):
+#     sign_in(driver, account_type="broadcast_create_user")
+
+#     # prepare alert
+#     current_alerts_page = BasePage(driver)
+#     test_uuid = str(uuid.uuid4())
+#     broadcast_title = "test broadcast " + test_uuid
+
+#     current_alerts_page.click_element_by_link_text("Create new alert")
+
+#     new_alert_page = BasePage(driver)
+#     new_alert_page.select_checkbox_or_radio(value="freeform")
+#     new_alert_page.click_continue()
+
+#     broadcast_freeform_page = BroadcastFreeformPage(driver)
+#     broadcast_content = "This is a test broadcast " + test_uuid
+#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+#     broadcast_freeform_page.click_continue()
+
+#     # Choosing to add exra_content to alert
+#     choose_extra_content_page = BasePage(driver)
+#     choose_extra_content_page.select_checkbox_or_radio(value="yes")
+#     choose_extra_content_page.click_continue()
+
+#     # Adding extra_content to textarea and submitting
+#     add_extra_content_page = ExtraContentPage(driver)
+#     extra_content = "This is extra content " + test_uuid
+#     add_extra_content_page.create_extra_content(extra_content)
+#     add_extra_content_page.click_continue()
+
+#     prepare_alert_pages = BasePage(driver)
+#     prepare_alert_pages.click_element_by_link_text("Countries")
+#     prepare_alert_pages.select_checkbox_or_radio(value="ctry19-W92000004")
+#     prepare_alert_pages.click_continue()
+#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+#     broadcast_duration_page = BroadcastDurationPage(driver)
+#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+#     broadcast_duration_page.click_preview()  # Preview alert
+
+#     # check for selected areas and duration
+#     preview_alert_page = BasePage(driver)
+#     assert preview_alert_page.text_is_on_page("Wales")
+#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+#     assert preview_alert_page.text_is_on_page(
+#         f"{broadcast_title} is waiting for approval"
+#     )
+
+#     preview_alert_page.sign_out()
+
+#     # approve the alert
+#     sign_in(driver, account_type="broadcast_approve_user")
+
+#     current_alerts_page.click_element_by_link_text(broadcast_title)
+#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+#     current_alerts_page.click_submit()
+#     assert current_alerts_page.text_is_on_page("since today at")
+#     alert_page_url = current_alerts_page.current_url
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Current alerts", broadcast_content
+#     )
+
+#     # get back to the alert page
+#     current_alerts_page.get(alert_page_url)
+
+#     # stop sending the alert
+#     current_alerts_page.click_element_by_link_text("Stop sending")
+#     current_alerts_page.click_submit()  # stop broadcasting
+#     assert current_alerts_page.text_is_on_page(
+#         "Stopped by Functional Tests - Broadcast User Approve"
+#     )
+#     current_alerts_page.click_element_by_link_text("Past alerts")
+#     past_alerts_page = BasePage(driver)
+#     assert past_alerts_page.text_is_on_page(broadcast_title)
+
+#     time.sleep(10)
+#     check_alert_is_published_on_govuk_alerts(
+#         driver, "Past alerts", broadcast_content, extra_content
+#     )
+
+#     current_alerts_page.get()
+#     current_alerts_page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -4,264 +4,287 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from config import config
 from tests.functional.preview_and_dev.sample_cap_xml import (
+    ALERT_XML,
+    CANCEL_XML,
     INVALID_AREA_ALERT_XML,
 )
-from tests.pages import BasePage
+from tests.pages import (
+    BasePage,
+    BroadcastDurationPage,
+    BroadcastFreeformPage,
+    CurrentAlertsPage,
+    ShowTemplatesPage,
+)
+from tests.pages.pages import (
+    ChooseCoordinateArea,
+    ChooseCoordinatesType,
+    ExtraContentPage,
+    RejectionForm,
+    ReturnAlertForEditForm,
+    SearchPostcodePage,
+)
 from tests.pages.rollups import sign_in
-from tests.test_utils import convert_naive_utc_datetime_to_cap_standard_string
+from tests.test_utils import (
+    check_alert_is_published_on_govuk_alerts,
+    convert_naive_utc_datetime_to_cap_standard_string,
+    create_broadcast_template,
+    delete_template,
+    go_to_templates_page,
+)
 
 test_group_name = "broadcast-flow"
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
 
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast " + test_uuid
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
 
-#     current_alerts_page.click_element_by_link_text("Create new alert")
+    current_alerts_page.click_element_by_link_text("Create new alert")
 
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
 
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
 
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
 
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
 
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
 
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
 
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
 
-#     preview_alert_page.sign_out()
+    preview_alert_page.sign_out()
 
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
 
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
 
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
 
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_template(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     go_to_templates_page(driver, service="broadcast_service")
-#     template_name = "test broadcast" + str(uuid.uuid4())
-#     content = "This is a test only."
-#     create_broadcast_template(driver, reference=template_name, content=content)
-
-#     current_alerts_page = CurrentAlertsPage(driver)
-#     current_alerts_page.go_to_service_landing_page(
-#         service_id=config["broadcast_service"]["id"]
-#     )
-#     current_alerts_page.click_element_by_link_text("Current alerts")
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="template")
-#     new_alert_page.click_continue()
-
-#     templates_page = ShowTemplatesPage(driver)
-#     templates_page.click_template_by_link_text(template_name)
-
-#     templates_page.click_element_by_link_text("Save and get ready to send")
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert prepare_alert_pages.text_is_on_page("Cokeham")
-#     assert prepare_alert_pages.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
-#     assert prepare_alert_pages.text_is_on_page(
-#         f"{template_name} is waiting for approval"
-#     )
-
-#     prepare_alert_pages.click_element_by_link_text("Discard this alert")
-#     prepare_alert_pages.click_element_by_link_text("Rejected alerts")
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.text_is_on_page(template_name)
-
-#     delete_template(driver, template_name, service="broadcast_service")
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc) - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc)
-#     )
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_template(driver):
+    sign_in(driver, account_type="broadcast_create_user")
 
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
+    go_to_templates_page(driver, service="broadcast_service")
+    template_name = "test broadcast" + str(uuid.uuid4())
+    content = "This is a test only."
+    create_broadcast_template(driver, reference=template_name, content=content)
 
-#     sign_in(driver, account_type="broadcast_approve_user")
-#     page = BasePage(driver)
-#     page.click_element_by_link_text(event)
+    current_alerts_page = CurrentAlertsPage(driver)
+    current_alerts_page.go_to_service_landing_page(
+        service_id=config["broadcast_service"]["id"]
+    )
+    current_alerts_page.click_element_by_link_text("Current alerts")
+    current_alerts_page.click_element_by_link_text("Create new alert")
 
-#     assert page.text_is_on_page(f"An API call wants to broadcast {event}")
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="template")
+    new_alert_page.click_continue()
 
-#     reject_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(reject_broadcast_xml)
+    templates_page = ShowTemplatesPage(driver)
+    templates_page.click_template_by_link_text(template_name)
 
-#     time.sleep(10)
-#     page.click_element_by_link_text("Rejected alerts")
-#     assert page.text_is_on_page(event)
+    templates_page.click_element_by_link_text("Save and get ready to send")
 
-#     page.get()
-#     page.sign_out()
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert prepare_alert_pages.text_is_on_page("Cokeham")
+    assert prepare_alert_pages.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    prepare_alert_pages.click_submit_for_approval()  # click "Submit for approval"
+    assert prepare_alert_pages.text_is_on_page(
+        f"{template_name} is waiting for approval"
+    )
+
+    prepare_alert_pages.click_element_by_link_text("Discard this alert")
+    prepare_alert_pages.click_element_by_link_text("Rejected alerts")
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.text_is_on_page(template_name)
+
+    delete_template(driver, template_name, service="broadcast_service")
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
-#     sent_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc) - timedelta(hours=1)
-#     )
-#     cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
-#         datetime.now(timezone.utc)
-#     )
-#     identifier = uuid.uuid4()
-#     event = f"test broadcast {identifier}"
-#     broadcast_content = f"Flood warning {identifier} has been issued"
+@pytest.mark.xdist_group(name=test_group_name)
+def test_create_and_then_reject_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
 
-#     new_alert_xml = ALERT_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         event=event,
-#         broadcast_content=broadcast_content,
-#     )
-#     broadcast_client.post_broadcast_data(new_alert_xml)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
 
-#     sign_in(driver, account_type="broadcast_approve_user")
+    sign_in(driver, account_type="broadcast_approve_user")
+    page = BasePage(driver)
+    page.click_element_by_link_text(event)
 
-#     page = BasePage(driver)
-#     page.click_element_by_link_text(event)
-#     page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     page.click_submit()
+    assert page.text_is_on_page(f"An API call wants to broadcast {event}")
 
-#     assert page.text_is_on_page("since today at")
+    reject_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(reject_broadcast_xml)
 
-#     alert_page_url = page.current_url
+    time.sleep(10)
+    page.click_element_by_link_text("Rejected alerts")
+    assert page.text_is_on_page(event)
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
+    page.get()
+    page.sign_out()
 
-#     cancel_broadcast_xml = CANCEL_XML.format(
-#         identifier=identifier,
-#         alert_sent=sent_time,
-#         cancel_sent=cancel_time,
-#         event=event,
-#     )
-#     broadcast_client.post_broadcast_data(cancel_broadcast_xml)
 
-#     # go back to the page for the current alert
-#     time.sleep(10)
-#     page.get(alert_page_url)
+@pytest.mark.xdist_group(name=test_group_name)
+def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+    cancel_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc)
+    )
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
 
-#     # assert that it's now cancelled
-#     assert page.text_is_on_page("Stopped by an API call")
-#     page.click_element_by_link_text("Past alerts")
-#     assert page.text_is_on_page(event)
+    new_alert_xml = ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(new_alert_xml)
 
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+    sign_in(driver, account_type="broadcast_approve_user")
 
-#     page.get()
-#     page.sign_out()
+    page = BasePage(driver)
+    page.click_element_by_link_text(event)
+    page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    page.click_submit()
+
+    assert page.text_is_on_page("since today at")
+
+    alert_page_url = page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    cancel_broadcast_xml = CANCEL_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        cancel_sent=cancel_time,
+        event=event,
+    )
+    broadcast_client.post_broadcast_data(cancel_broadcast_xml)
+
+    # go back to the page for the current alert
+    time.sleep(10)
+    page.get(alert_page_url)
+
+    # assert that it's now cancelled
+    assert page.text_is_on_page("Stopped by an API call")
+    page.click_element_by_link_text("Past alerts")
+    assert page.text_is_on_page(event)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    page.get()
+    page.sign_out()
 
 
 @pytest.mark.xdist_group(name=test_group_name)
@@ -303,553 +326,553 @@ def test_create_broadcast_with_invalid_area_then_discard(driver, broadcast_clien
     page.sign_out()
 
 
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast" + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Postcode areas")
-#     # This is where it varies
-#     search_postcode_page = SearchPostcodePage(driver)
-#     postcode_to_search = "BD1 1EE"
-#     radius_to_add = "5"
-#     search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
-#     search_postcode_page.click_search()
-#     # assert areas appear here
-
-#     search_postcode_page.click_continue()
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # here check if selected areas displayed
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page(
-#         "5km around the postcode BD1 1EE in Bradford"
-#     )
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# @pytest.mark.parametrize(
-#     "coordinate_type, post_data, expected_area_description",
-#     (
-#         (
-#             "easting_northing",
-#             {
-#                 "first_coordinate": "416567",
-#                 "second_coordinate": "432994",
-#                 "radius": "3",
-#             },
-#             "3km around the easting of 416567 and the northing of 432994 in Bradford",
-#         ),
-#         (
-#             "latitude_longitude",
-#             {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
-#             "3km around 53.793 latitude, -1.75 longitude in Bradford",
-#         ),
-#     ),
-# )
-# def test_prepare_broadcast_with_new_content_for_coordinate_area(
-#     driver, coordinate_type, post_data, expected_area_description
-# ):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast{test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Coordinates")
-#     # This is where it varies
-#     choose_type_page = ChooseCoordinatesType(driver)
-#     choose_type_page.select_checkbox_or_radio(value=coordinate_type)
-#     choose_type_page.click_continue()
-
-#     choose_coordinate_area_page = ChooseCoordinateArea(driver)
-#     choose_coordinate_area_page.create_coordinate_area(
-#         post_data["first_coordinate"],
-#         post_data["second_coordinate"],
-#         post_data["radius"],
-#     )
-#     choose_coordinate_area_page.click_search()
-#     choose_coordinate_area_page.click_continue()
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # here check if selected areas displayed
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page(expected_area_description)
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_REPPIR_site_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast " + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
-#     prepare_alert_pages.select_checkbox_or_radio(
-#         value="REPPIR_DEPZ_sites-awe_aldermaston"
-#     )
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("AWE Aldermaston")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_reject_alert_with_reason(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast {test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # reject the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-#     alert_page_with_rejection = RejectionForm(driver)
-#     assert alert_page_with_rejection.rejection_details_is_closed()
-#     alert_page_with_rejection.click_open_reject_detail()
-#     assert alert_page_with_rejection.rejection_details_is_open()
-
-#     # Without rejection reason
-#     rejection_reason = ""
-#     alert_page_with_rejection.click_reject_alert()
-
-#     # Assert errors appear
-#     assert (
-#         alert_page_with_rejection.get_rejection_form_errors()
-#         == "Error:\nEnter the reason for rejecting the alert"
-#     )
-
-#     # With rejection reason
-#     rejection_reason = "This is a test rejection reason."
-#     alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
-#     alert_page_with_rejection.click_reject_alert()
-
-#     assert current_alerts_page.text_is_on_page("Current alerts")
-#     current_alerts_page.click_element_by_link_text("Rejected alerts")
-
-#     rejected_alerts_page = BasePage(driver)
-#     assert rejected_alerts_page.text_is_on_page(broadcast_title)
-#     assert rejected_alerts_page.text_is_on_page(rejection_reason)
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_return_alert_for_edit(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = f"test broadcast {test_uuid}"
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = f"This is a test broadcast {test_uuid}"
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing not to add extra_content
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="no")
-#     choose_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Local authorities")
-#     prepare_alert_pages.click_element_by_link_text("Adur")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-#     prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Cokeham")
-#     assert preview_alert_page.text_is_on_page("Eastbrook")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # Return the alert for edit
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
-
-#     alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
-#     assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
-#     alert_page_with_return_for_edit.click_open_return_for_edit_detail()
-#     assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
-
-#     # Without rejection reason
-#     reason_for_returning_alert = ""
-#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-#         reason_for_returning_alert
-#     )
-#     alert_page_with_return_for_edit.click_return_alert_for_edit()
-
-#     # Assert errors appear
-#     assert (
-#         alert_page_with_return_for_edit.get_return_for_edit_form_errors()
-#         == "Error:\nEnter the reason for returning the alert for edit"
-#     )
-
-#     # With reason for returning alert for edit
-#     reason_for_returning_alert = (
-#         "This is a test reason for returning the alert for edit."
-#     )
-#     alert_page_with_return_for_edit.create_return_for_edit_reason_input(
-#         reason_for_returning_alert
-#     )
-#     alert_page_with_return_for_edit.click_return_alert_for_edit()
-#     assert (
-#         f"This alert has been returned to edit, because: {reason_for_returning_alert}"
-#         in alert_page_with_return_for_edit.get_returned_banner_text()
-#     )
-#     assert alert_page_with_return_for_edit.text_is_on_page(
-#         "Submitted by Functional Tests - Broadcast User Create"
-#     )
-#     assert alert_page_with_return_for_edit.text_is_on_page(
-#         "Returned by Functional Tests - Broadcast User Approve"
-#     )
-
-#     assert current_alerts_page.text_is_on_page("Current alerts")
-#     assert current_alerts_page.text_is_on_page(broadcast_title)
-
-
-# @pytest.mark.xdist_group(name=test_group_name)
-# def test_prepare_broadcast_with_extra_content(driver):
-#     sign_in(driver, account_type="broadcast_create_user")
-
-#     # prepare alert
-#     current_alerts_page = BasePage(driver)
-#     test_uuid = str(uuid.uuid4())
-#     broadcast_title = "test broadcast " + test_uuid
-
-#     current_alerts_page.click_element_by_link_text("Create new alert")
-
-#     new_alert_page = BasePage(driver)
-#     new_alert_page.select_checkbox_or_radio(value="freeform")
-#     new_alert_page.click_continue()
-
-#     broadcast_freeform_page = BroadcastFreeformPage(driver)
-#     broadcast_content = "This is a test broadcast " + test_uuid
-#     broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
-#     broadcast_freeform_page.click_continue()
-
-#     # Choosing to add exra_content to alert
-#     choose_extra_content_page = BasePage(driver)
-#     choose_extra_content_page.select_checkbox_or_radio(value="yes")
-#     choose_extra_content_page.click_continue()
-
-#     # Adding extra_content to textarea and submitting
-#     add_extra_content_page = ExtraContentPage(driver)
-#     extra_content = "This is extra content " + test_uuid
-#     add_extra_content_page.create_extra_content(extra_content)
-#     add_extra_content_page.click_continue()
-
-#     prepare_alert_pages = BasePage(driver)
-#     prepare_alert_pages.click_element_by_link_text("Countries")
-#     prepare_alert_pages.select_checkbox_or_radio(value="ctry19-W92000004")
-#     prepare_alert_pages.click_continue()
-#     prepare_alert_pages.click_element_by_link_text("Save and continue")
-
-#     broadcast_duration_page = BroadcastDurationPage(driver)
-#     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
-#     broadcast_duration_page.click_preview()  # Preview alert
-
-#     # check for selected areas and duration
-#     preview_alert_page = BasePage(driver)
-#     assert preview_alert_page.text_is_on_page("Wales")
-#     assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
-
-#     preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
-#     assert preview_alert_page.text_is_on_page(
-#         f"{broadcast_title} is waiting for approval"
-#     )
-
-#     preview_alert_page.sign_out()
-
-#     # approve the alert
-#     sign_in(driver, account_type="broadcast_approve_user")
-
-#     current_alerts_page.click_element_by_link_text(broadcast_title)
-#     current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
-#     current_alerts_page.click_submit()
-#     assert current_alerts_page.text_is_on_page("since today at")
-#     alert_page_url = current_alerts_page.current_url
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Current alerts", broadcast_content
-#     )
-
-#     # get back to the alert page
-#     current_alerts_page.get(alert_page_url)
-
-#     # stop sending the alert
-#     current_alerts_page.click_element_by_link_text("Stop sending")
-#     current_alerts_page.click_submit()  # stop broadcasting
-#     assert current_alerts_page.text_is_on_page(
-#         "Stopped by Functional Tests - Broadcast User Approve"
-#     )
-#     current_alerts_page.click_element_by_link_text("Past alerts")
-#     past_alerts_page = BasePage(driver)
-#     assert past_alerts_page.text_is_on_page(broadcast_title)
-
-#     time.sleep(10)
-#     check_alert_is_published_on_govuk_alerts(
-#         driver, "Past alerts", broadcast_content, extra_content
-#     )
-
-#     current_alerts_page.get()
-#     current_alerts_page.sign_out()
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_new_content_for_postcode_area(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast" + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Postcode areas")
+    # This is where it varies
+    search_postcode_page = SearchPostcodePage(driver)
+    postcode_to_search = "BD1 1EE"
+    radius_to_add = "5"
+    search_postcode_page.create_custom_area(postcode_to_search, radius_to_add)
+    search_postcode_page.click_search()
+    # assert areas appear here
+
+    search_postcode_page.click_continue()
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # here check if selected areas displayed
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page(
+        "5km around the postcode BD1 1EE in Bradford"
+    )
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "coordinate_type, post_data, expected_area_description",
+    (
+        (
+            "easting_northing",
+            {
+                "first_coordinate": "416567",
+                "second_coordinate": "432994",
+                "radius": "3",
+            },
+            "3km around the easting of 416567 and the northing of 432994 in Bradford",
+        ),
+        (
+            "latitude_longitude",
+            {"first_coordinate": "53.793", "second_coordinate": "-1.75", "radius": "3"},
+            "3km around 53.793 latitude, -1.75 longitude in Bradford",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_new_content_for_coordinate_area(
+    driver, coordinate_type, post_data, expected_area_description
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast{test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Coordinates")
+    # This is where it varies
+    choose_type_page = ChooseCoordinatesType(driver)
+    choose_type_page.select_checkbox_or_radio(value=coordinate_type)
+    choose_type_page.click_continue()
+
+    choose_coordinate_area_page = ChooseCoordinateArea(driver)
+    choose_coordinate_area_page.create_coordinate_area(
+        post_data["first_coordinate"],
+        post_data["second_coordinate"],
+        post_data["radius"],
+    )
+    choose_coordinate_area_page.click_search()
+    choose_coordinate_area_page.click_continue()
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # here check if selected areas displayed
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page(expected_area_description)
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_REPPIR_site_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("REPPIR DEPZ sites")
+    prepare_alert_pages.select_checkbox_or_radio(
+        value="REPPIR_DEPZ_sites-awe_aldermaston"
+    )
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("AWE Aldermaston")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_reject_alert_with_reason(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast {test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # reject the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_rejection = RejectionForm(driver)
+    assert alert_page_with_rejection.rejection_details_is_closed()
+    alert_page_with_rejection.click_open_reject_detail()
+    assert alert_page_with_rejection.rejection_details_is_open()
+
+    # Without rejection reason
+    rejection_reason = ""
+    alert_page_with_rejection.click_reject_alert()
+
+    # Assert errors appear
+    assert (
+        alert_page_with_rejection.get_rejection_form_errors()
+        == "Error:\nEnter the reason for rejecting the alert"
+    )
+
+    # With rejection reason
+    rejection_reason = "This is a test rejection reason."
+    alert_page_with_rejection.create_rejection_reason_input(rejection_reason)
+    alert_page_with_rejection.click_reject_alert()
+
+    assert current_alerts_page.text_is_on_page("Current alerts")
+    current_alerts_page.click_element_by_link_text("Rejected alerts")
+
+    rejected_alerts_page = BasePage(driver)
+    assert rejected_alerts_page.text_is_on_page(broadcast_title)
+    assert rejected_alerts_page.text_is_on_page(rejection_reason)
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_return_alert_for_edit(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = f"test broadcast {test_uuid}"
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = f"This is a test broadcast {test_uuid}"
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+    prepare_alert_pages.click_element_by_link_text("Adur")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Cokeham")
+    assert preview_alert_page.text_is_on_page("Eastbrook")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # Return the alert for edit
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)  # to access alert
+
+    alert_page_with_return_for_edit = ReturnAlertForEditForm(driver)
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_closed()
+    alert_page_with_return_for_edit.click_open_return_for_edit_detail()
+    assert alert_page_with_return_for_edit.return_for_edit_details_is_open()
+
+    # Without rejection reason
+    reason_for_returning_alert = ""
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
+
+    # Assert errors appear
+    assert (
+        alert_page_with_return_for_edit.get_return_for_edit_form_errors()
+        == "Error:\nEnter the reason for returning the alert for edit"
+    )
+
+    # With reason for returning alert for edit
+    reason_for_returning_alert = (
+        "This is a test reason for returning the alert for edit."
+    )
+    alert_page_with_return_for_edit.create_return_for_edit_reason_input(
+        reason_for_returning_alert
+    )
+    alert_page_with_return_for_edit.click_return_alert_for_edit()
+    assert (
+        f"This alert has been returned to edit, because: {reason_for_returning_alert}"
+        in alert_page_with_return_for_edit.get_returned_banner_text()
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Submitted by Functional Tests - Broadcast User Create"
+    )
+    assert alert_page_with_return_for_edit.text_is_on_page(
+        "Returned by Functional Tests - Broadcast User Approve"
+    )
+
+    assert current_alerts_page.text_is_on_page("Current alerts")
+    assert current_alerts_page.text_is_on_page(broadcast_title)
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_extra_content(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing to add exra_content to alert
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="yes")
+    choose_extra_content_page.click_continue()
+
+    # Adding extra_content to textarea and submitting
+    add_extra_content_page = ExtraContentPage(driver)
+    extra_content = "This is extra content " + test_uuid
+    add_extra_content_page.create_extra_content(extra_content)
+    add_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Countries")
+    prepare_alert_pages.select_checkbox_or_radio(value="ctry19-W92000004")
+    prepare_alert_pages.click_continue()
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Wales")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Past alerts", broadcast_content, extra_content
+    )
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -286,8 +286,6 @@ def test_create_broadcast_with_invalid_area_then_discard(driver, broadcast_clien
     page = BasePage(driver)
     page.click_element_by_link_text(event)
 
-    assert page.text_is_on_page(event)
-
     # Asserts that error message appears on page
     assert page.get_errors_from_error_summary() == (
         "The area used is invalid and the alert cannot be sent. "

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -8,6 +8,7 @@ from config import config
 from tests.functional.preview_and_dev.sample_cap_xml import (
     ALERT_XML,
     CANCEL_XML,
+    INVALID_AREA_ALERT_XML,
 )
 from tests.pages import (
     BasePage,
@@ -281,6 +282,47 @@ def test_cancel_live_broadcast_using_the_api(driver, broadcast_client):
 
     time.sleep(10)
     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    page.get()
+    page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_create_broadcast_with_invalid_area_then_discard(driver, broadcast_client):
+    sent_time = convert_naive_utc_datetime_to_cap_standard_string(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+    identifier = uuid.uuid4()
+    event = f"test broadcast {identifier}"
+    broadcast_content = f"Flood warning {identifier} has been issued"
+
+    # XML polygon has a self-intersecting point so is invalid
+    invalid_area_alert_xml = INVALID_AREA_ALERT_XML.format(
+        identifier=identifier,
+        alert_sent=sent_time,
+        event=event,
+        broadcast_content=broadcast_content,
+    )
+    broadcast_client.post_broadcast_data(invalid_area_alert_xml)
+
+    sign_in(driver, account_type="broadcast_approve_user")
+    page = BasePage(driver)
+    page.click_element_by_link_text(event)
+
+    assert page.text_is_on_page(event)
+
+    # Asserts that error message appears on page
+    assert page.get_errors_from_error_summary() == (
+        "The area used is invalid and the alert cannot be sent. "
+        "If the alert was created through the API, report it to the alert creator. "
+        "Otherwise report it to the Emergency Alerts team."
+    )
+
+    page.click_element_by_link_text("Discard this alert")
+
+    time.sleep(10)
+    page.click_element_by_link_text("Rejected alerts")
+    assert page.text_is_on_page(event)
 
     page.get()
     page.sign_out()

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -363,6 +363,11 @@ class BasePage(object):
         errors = self.wait_for_element(error_message)
         return errors.text.strip()
 
+    def get_errors_from_error_summary(self):
+        error_message = (By.CSS_SELECTOR, ".govuk-error-summary")
+        errors = self.wait_for_element(error_message)
+        return errors.text.strip()
+
 
 class PageWithStickyNavMixin:
     def scrollToRevealElement(self, selector=None, xpath=None, stuckToBottom=True):


### PR DESCRIPTION
This PR adds a test that asserts that an alert, created via API call, with an invalid area displays an error and users are unable to approve the alert.