### PR TITLE
EAS-2926 - fix failing 'test_sign_in_with_email_mfa' functional test

### DIFF
--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -100,5 +100,4 @@ def test_sign_in_with_email_mfa(driver, purge_failed_logins):
 
     landing_page = BasePage(driver)
     landing_page.get(sign_in_url)
-
-    landing_page.url_contains("current-alerts")
+    assert landing_page.text_is_on_page("Sign out")

--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -13,7 +13,11 @@ from tests.pages import (
     VerifyPage,
 )
 from tests.pages.rollups import clean_session
-from tests.test_utils import create_sign_in_url, get_verification_code_by_id
+from tests.test_utils import (
+    create_email_mfa_sign_in_url,
+    create_sign_in_url,
+    get_verification_code_by_id,
+)
 
 test_group_name = "auth-flow"
 
@@ -76,6 +80,7 @@ def test_sign_in_with_email_mfa(driver, purge_failed_logins):
     home_page.get()
     home_page.accept_cookie_warning()
 
+    login_id = config["broadcast_service"]["broadcast_user_4"]["id"]
     login_email = config["broadcast_service"]["broadcast_user_4"]["email"]
     login_pw = config["broadcast_service"]["broadcast_user_4"]["password"]
 
@@ -89,7 +94,9 @@ def test_sign_in_with_email_mfa(driver, purge_failed_logins):
     assert sign_in_page.text_is_on_page("a link to sign in")
 
     purge_failed_logins()
-    sign_in_url = create_sign_in_url(login_email, "email-auth")
+
+    verify_code = get_verification_code_by_id(login_id)
+    sign_in_url = create_email_mfa_sign_in_url(login_id, verify_code, "email-auth")
 
     landing_page = BasePage(driver)
     landing_page.get(sign_in_url)

--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -100,4 +100,4 @@ def test_sign_in_with_email_mfa(driver, purge_failed_logins):
 
     landing_page = BasePage(driver)
     landing_page.get(sign_in_url)
-    assert landing_page.text_is_on_page("Sign out")
+    assert landing_page.text_is_on_page("Switch service")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,6 +245,20 @@ def create_sign_in_url(email, url, next_redirect=None):
     return full_url
 
 
+def create_email_mfa_sign_in_url(userid, secret_code, url, next_redirect=None):
+    data = json.dumps(
+        {
+            "user_id": userid,
+            "secret_code": secret_code,
+            "created_at": str(datetime.now(timezone.utc)),
+        }
+    )
+    full_url = _url_with_token(data, f"/{url}/", config)
+    if next_redirect:
+        full_url += "?{}".format(urlencode({"next": next_redirect}))
+    return full_url
+
+
 def create_invitation_url(user_id):
     return _url_with_token(user_id, "/invitation/", config)
 


### PR DESCRIPTION
Generate email mfa login url with correct tokens, and add an assert to confirm user has actually logged in (test was previously passing even though login was failing with an application error).