### PR TITLE
Adds tests, elements, locators and page for asserting bulk flood warn…

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -17,6 +17,7 @@ from tests.pages import (
     ShowTemplatesPage,
 )
 from tests.pages.pages import (
+    AddAreasAsListPage,
     ChooseCoordinateArea,
     ChooseCoordinatesType,
     ExtraContentPage,
@@ -661,6 +662,186 @@ def test_prepare_broadcast_with_flood_warning_target_area(driver):
 
     time.sleep(10)
     check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_multiple_flood_warning_target_areas(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text(
+        "Flood Warning Target Areas (TA code)"
+    )
+
+    search_flood_warning_area_page = SearchFloodWarningAreaPage(driver)
+
+    # Click link to page to bulk add
+    search_flood_warning_area_page.click_element_by_link_text(
+        "enter a list into one text box"
+    )
+
+    bulk_add_areas_page = AddAreasAsListPage(driver)
+
+    flood_warning_area_ta_codes = ["122FWB112", "031FWFSE440", "031FWFTE125"]
+
+    bulk_add_areas_page.create_area_list_input(",".join(flood_warning_area_ta_codes))
+    bulk_add_areas_page.click_add_areas()
+
+    # Asserts that both areas area displayed
+    assert search_flood_warning_area_page.text_is_on_page("122FWB112: Hull city centre")
+    assert search_flood_warning_area_page.text_is_on_page(
+        "031FWFSE440: River Severn at Hylton Road, Worcester"
+    )
+    assert search_flood_warning_area_page.text_is_on_page(
+        " 031FWFTE125: River Teme at Toronto Close Lower Wick"
+    )
+
+    search_flood_warning_area_page.click_element_by_link_text(
+        "Save and continue to preview"
+    )
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Hull city centre")
+    assert preview_alert_page.text_is_on_page("River Severn at Hylton Road, Worcester")
+    assert preview_alert_page.text_is_on_page("River Teme at Toronto Close Lower Wick")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_submit_for_approval()  # click "Submit for approval"
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "post_data, expected_error",
+    (
+        (
+            [],
+            "Enter at least 1 Flood Warning TA code",
+        ),
+        (
+            ["test"],
+            "Flood Warning TA code not found",
+        ),
+        (
+            ["031FWFSE440", "031FWFSE440"],
+            "All Flood Warning TA codes must be unique",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_invalid_bulk_flood_warning_areas(
+    driver, post_data, expected_error
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text(
+        "Flood Warning Target Areas (TA code)"
+    )
+
+    search_flood_warning_area_page = SearchFloodWarningAreaPage(driver)
+
+    # Click link to page to bulk add
+    search_flood_warning_area_page.click_element_by_link_text(
+        "enter a list into one text box"
+    )
+
+    bulk_add_areas_page = AddAreasAsListPage(driver)
+
+    bulk_add_areas_page.create_area_list_input(",".join(post_data))
+    bulk_add_areas_page.click_add_areas()
+
+    # Assert errors appear
+    assert (
+        bulk_add_areas_page.get_errors_from_error_summary()
+        == f"There is a problem\n{expected_error}"
+    )
 
     current_alerts_page.get()
     current_alerts_page.sign_out()

--- a/tests/pages/element.py
+++ b/tests/pages/element.py
@@ -1,4 +1,5 @@
 from tests.pages.locators import (
+    AddAreasAsListPageLocators,
     AddServicePageLocators,
     ApiKeysPageLocators,
     CommonPageLocators,
@@ -210,3 +211,11 @@ class FloodWarningAreaCodeInputElement(BasePageElement):
 
 class AddAreaButton(BasePageElement):
     name = SearchFloodWarningAreaPageLocators.ADD_AREA_BUTTON[1]
+
+
+class AddAreasAsListInputElement(BasePageElement):
+    name = AddAreasAsListPageLocators.AREA_LIST_INPUT[1]
+
+
+class AddAreasAsListButton(BasePageElement):
+    name = AddAreasAsListPageLocators.ADD_AREA_LIST_BUTTON[1]

--- a/tests/pages/locators.py
+++ b/tests/pages/locators.py
@@ -200,6 +200,11 @@ class SearchFloodWarningAreaPageLocators(object):
     ADD_AREA_BUTTON = (By.NAME, "add_area_button")
 
 
+class AddAreasAsListPageLocators(object):
+    AREA_LIST_INPUT = (By.NAME, "areas")
+    ADD_AREA_LIST_BUTTON = (By.NAME, "add_area_button")
+
+
 class PlatformAdminPageLocators(object):
     SEARCH_INPUT = (By.NAME, "search")
 

--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -8,6 +8,7 @@ from retry import retry
 
 from config import config
 from tests.pages.element import (
+    AddAreasAsListInputElement,
     BasePageElement,
     ClearableInputElement,
     CoordinatePreviewButton,
@@ -49,6 +50,7 @@ from tests.pages.element import (
     TemplateContentElement,
 )
 from tests.pages.locators import (
+    AddAreasAsListPageLocators,
     AddServicePageLocators,
     AdminApprovalPageLocators,
     ApiIntegrationPageLocators,
@@ -1335,6 +1337,17 @@ class SearchFloodWarningAreaPage(BasePage):
         element = self.wait_for_element(
             SearchFloodWarningAreaPageLocators.ADD_AREA_BUTTON
         )
+        element.click()
+
+
+class AddAreasAsListPage(BasePage):
+    areas_list_input = AddAreasAsListInputElement()
+
+    def create_area_list_input(self, areas_list):
+        self.areas_list_input = areas_list
+
+    def click_add_areas(self):
+        element = self.wait_for_element(AddAreasAsListPageLocators.ADD_AREA_LIST_BUTTON)
         element.click()
 
 


### PR DESCRIPTION
This PR adds tests that assert that Flood Warning areas can be added to the alert as a list, and also that if incorrect input provided the correct error messaging is displayed.
The following changes have been made in this PR:
- `test_prepare_broadcast_with_multiple_flood_warning_target_areas` and `test_prepare_broadcast_with_invalid_bulk_flood_warning_areas` tests added
- Necessary page, elements and locators have been added for the tests