### PR TITLE
EAS-2969: Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,27 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-yaml
   - id: debug-statements
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.3.0
-  hooks:
-  - id: flake8
-    name: flake8 (python)
-- repo: https://github.com/PyCQA/isort
-  rev: 8.0.1
-  hooks:
-    - id: isort
-      name: isort (python)
-- repo: https://github.com/psf/black
-  rev: 26.3.0
+- repo: local
   hooks:
     - id: black
-      name: black (python)
+      name: black
+      entry: black
+      language: system
+      types: [python]
+
+    - id: flake8
+      name: flake8
+      entry: flake8
+      language: system
+      types: [python]
+
+    - id: isort
+      name: isort
+      entry: isort
+      language: system
+      types: [python]


### PR DESCRIPTION
Update pre-commit-hooks version, and include lint tools from local python venv, instead of pinning specific versions - this will make future updates to lint tools via i.e. dependabot PRs much easier to manage.