### PR TITLE
Try to wait for JS to load for sticky-relevant behaviour

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -311,17 +311,23 @@ class BasePage(object):
 
 
 class PageWithStickyNavMixin:
+
     def scrollToRevealElement(self, selector=None, xpath=None, stuckToBottom=True):
+        driver: PlaywrightDriver = self.driver
+
         namespace = "window.GOVUK.stickAtBottomWhenScrolling"
         if stuckToBottom is False:
             namespace = "window.GOVUK.stickAtTopWhenScrolling"
+
+        # We need to wait for the JS to initialise and set the relevant global before using it
+        driver.page.wait_for_function(f"() => {namespace}")
 
         if selector is not None:
             js_str = (
                 f"if ('scrollToRevealElement' in {namespace})"
                 f"{namespace}.scrollToRevealElement($('{selector}').eq(0))"
             )
-            self.driver.execute_script(js_str)
+            driver.execute_script(js_str)
         elif xpath is not None:
             js_str = f"""(function (document) {{
                              if ('scrollToRevealElement' in {namespace}) {{
@@ -331,7 +337,7 @@ class PageWithStickyNavMixin:
                                  }}
                              }}
                          }}(document));"""
-            self.driver.execute_script(js_str)
+            driver.execute_script(js_str)
 
 
 class HomePage(BasePage):


### PR DESCRIPTION
The template changes can be a tad flaky - operating so fast that the JavaScript hasn't initialised yet on the page. This now waits for the relevant JS object to resolve to something that's truthy before triyng to invoke it.

<img width="1079" height="764" alt="image" src="https://github.com/user-attachments/assets/eb3b4192-1342-42ae-9630-ec011fe06148" />
