### PR TITLE
EAS-2878: Adds functional tests for bulk adding local authorities

### DIFF
--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -1036,7 +1036,7 @@ def test_prepare_broadcast_with_multiple_local_authorities(driver):
     assert prepare_alert_pages.text_is_on_page("Adur")
     assert prepare_alert_pages.text_is_on_page("Kingston upon Hull, City of")
 
-    prepare_alert_pages.click_element_by_link_text("Save and continue to preview")
+    prepare_alert_pages.click_element_by_link_text("Save and continue")
 
     broadcast_duration_page = BroadcastDurationPage(driver)
     broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
@@ -1141,7 +1141,7 @@ def test_prepare_broadcast_with_invalid_bulk_local_authority_input(
 
     bulk_add_areas_page = AddAreasAsListPage(driver)
 
-    bulk_add_areas_page.create_area_list_input(",".join(post_data))
+    bulk_add_areas_page.create_area_list_input("\n".join(post_data))
     bulk_add_areas_page.click_add_areas()
 
     # Assert errors appear

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -994,6 +994,167 @@ def test_prepare_broadcast_with_invalid_bulk_flood_warning_areas(
 
 
 @pytest.mark.xdist_group(name=test_group_name)
+def test_prepare_broadcast_with_multiple_local_authorities(driver):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+
+    # Click link to page to bulk add
+    prepare_alert_pages.click_element_by_link_text("enter a list into one text box")
+
+    bulk_add_areas_page = AddAreasAsListPage(driver)
+
+    local_authorities = ["Kingston upon Hull, City of", "Adur"]
+
+    bulk_add_areas_page.create_area_list_input("\n".join(local_authorities))
+    bulk_add_areas_page.click_add_areas()
+
+    # Asserts that both areas area displayed
+    assert prepare_alert_pages.text_is_on_page("Kingston upon Hull, City of")
+    assert prepare_alert_pages.text_is_on_page("Adur")
+    assert prepare_alert_pages.text_is_on_page("Kingston upon Hull, City of")
+
+    prepare_alert_pages.click_element_by_link_text("Save and continue to preview")
+
+    broadcast_duration_page = BroadcastDurationPage(driver)
+    broadcast_duration_page.set_alert_duration(hours="8", minutes="30")
+    broadcast_duration_page.click_preview()  # Preview alert
+
+    # check for selected areas and duration
+    preview_alert_page = BasePage(driver)
+    assert preview_alert_page.text_is_on_page("Kingston upon Hull, City of")
+    assert preview_alert_page.text_is_on_page("Adur")
+    assert preview_alert_page.text_is_on_page("8 hours, 30 minutes")
+
+    preview_alert_page.click_element_by_link_text("Submit for approval")
+    assert preview_alert_page.text_is_on_page(
+        f"{broadcast_title} is waiting for approval"
+    )
+
+    preview_alert_page.sign_out()
+
+    # approve the alert
+    sign_in(driver, account_type="broadcast_approve_user")
+
+    current_alerts_page.click_element_by_link_text(broadcast_title)
+    current_alerts_page.select_checkbox_or_radio(value="y")  # confirm approve alert
+    current_alerts_page.click_submit()
+    assert current_alerts_page.text_is_on_page("since today at")
+    alert_page_url = current_alerts_page.current_url
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(
+        driver, "Current alerts", broadcast_content
+    )
+
+    # get back to the alert page
+    current_alerts_page.get(alert_page_url)
+
+    # stop sending the alert
+    current_alerts_page.click_element_by_link_text("Stop sending")
+    current_alerts_page.click_submit()  # stop broadcasting
+    assert current_alerts_page.text_is_on_page(
+        "Stopped by Functional Tests - Broadcast User Approve"
+    )
+    current_alerts_page.click_element_by_link_text("Past alerts")
+    past_alerts_page = BasePage(driver)
+    assert past_alerts_page.text_is_on_page(broadcast_title)
+
+    time.sleep(10)
+    check_alert_is_published_on_govuk_alerts(driver, "Past alerts", broadcast_content)
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
+@pytest.mark.parametrize(
+    "post_data, expected_error",
+    (
+        (
+            [],
+            "Enter at least 1 local authority",
+        ),
+        (
+            ["Adu"],
+            "Local authority not found",
+        ),
+        (
+            ["Adur", "Adur"],
+            "All local authorities must be unique",
+        ),
+    ),
+)
+def test_prepare_broadcast_with_invalid_bulk_local_authority_input(
+    driver, post_data, expected_error
+):
+    sign_in(driver, account_type="broadcast_create_user")
+
+    # prepare alert
+    current_alerts_page = BasePage(driver)
+    test_uuid = str(uuid.uuid4())
+    broadcast_title = "test broadcast " + test_uuid
+
+    current_alerts_page.click_element_by_link_text("Create new alert")
+
+    new_alert_page = BasePage(driver)
+    new_alert_page.select_checkbox_or_radio(value="freeform")
+    new_alert_page.click_continue()
+
+    broadcast_freeform_page = BroadcastFreeformPage(driver)
+    broadcast_content = "This is a test broadcast " + test_uuid
+    broadcast_freeform_page.create_broadcast_content(broadcast_title, broadcast_content)
+    broadcast_freeform_page.click_continue()
+
+    # Choosing not to add extra_content
+    choose_extra_content_page = BasePage(driver)
+    choose_extra_content_page.select_checkbox_or_radio(value="no")
+    choose_extra_content_page.click_continue()
+
+    prepare_alert_pages = BasePage(driver)
+    prepare_alert_pages.click_element_by_link_text("Local authorities")
+
+    # Click link to page to bulk add
+    prepare_alert_pages.click_element_by_link_text("enter a list into one text box")
+
+    bulk_add_areas_page = AddAreasAsListPage(driver)
+
+    bulk_add_areas_page.create_area_list_input(",".join(post_data))
+    bulk_add_areas_page.click_add_areas()
+
+    # Assert errors appear
+    assert (
+        bulk_add_areas_page.get_errors_from_error_summary()
+        == f"There is a problem\n{expected_error}"
+    )
+
+    current_alerts_page.get()
+    current_alerts_page.sign_out()
+
+
+@pytest.mark.xdist_group(name=test_group_name)
 def test_reject_alert_with_reason(driver):
     sign_in(driver, account_type="broadcast_create_user")
 


### PR DESCRIPTION
This PR adds functional tests asserting the functionality, allowing users to enter multiple local authorities into text area to be added to an alert, works as it should.