### PR TITLE
EAS-2606: Updates electoral ward IDs for 2025 data

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,10 @@ import uuid
 
 import pytest
 
+# Electoral Ward IDs used throughout the tests
+COKEHAM_WARD_ID = "wd25-E05007564"
+EASTBROOK_WARD_ID = "wd25-E05007565"
+
 
 def generate_unique_email(email, uuid):
     parts = email.split("@")

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -66,8 +66,8 @@ def test_prepare_broadcast_with_new_content(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -206,7 +206,7 @@ def test_filter_sort_and_delete_all_drafts(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -301,8 +301,8 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -1182,8 +1182,8 @@ def test_reject_alert_with_reason(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -1265,8 +1265,8 @@ def test_return_alert_for_edit(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd23-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 

--- a/tests/functional/preview_and_dev/test_broadcast_flow.py
+++ b/tests/functional/preview_and_dev/test_broadcast_flow.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from config import config
+from config import COKEHAM_WARD_ID, EASTBROOK_WARD_ID, config
 from tests.functional.preview_and_dev.sample_cap_xml import (
     ALERT_XML,
     CANCEL_XML,
@@ -66,8 +66,8 @@ def test_prepare_broadcast_with_new_content(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    prepare_alert_pages.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -206,7 +206,7 @@ def test_filter_sort_and_delete_all_drafts(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
+    prepare_alert_pages.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -301,8 +301,8 @@ def test_prepare_broadcast_with_template(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    prepare_alert_pages.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -1182,8 +1182,8 @@ def test_reject_alert_with_reason(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    prepare_alert_pages.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 
@@ -1265,8 +1265,8 @@ def test_return_alert_for_edit(driver):
     prepare_alert_pages = BasePage(driver)
     prepare_alert_pages.click_element_by_link_text("Local authorities")
     prepare_alert_pages.click_element_by_link_text("Adur")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007564")
-    prepare_alert_pages.select_checkbox_or_radio(value="wd25-E05007565")
+    prepare_alert_pages.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    prepare_alert_pages.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     prepare_alert_pages.click_continue()
     prepare_alert_pages.click_element_by_link_text("Save and continue")
 

--- a/tests/functional/preview_and_dev/test_template_flow.py
+++ b/tests/functional/preview_and_dev/test_template_flow.py
@@ -73,8 +73,8 @@ def test_create_and_delete_template_with_area_only(driver):
     choose_template_area_page = BasePage(driver)
     choose_template_area_page.click_element_by_link_text("Local authorities")
     choose_template_area_page.click_element_by_link_text("Adur")
-    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007564")
-    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007565")
+    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007564")
+    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007565")
     choose_template_area_page.click_continue()
     choose_template_area_page.click_element_by_link_text("Save and continue")
 
@@ -193,8 +193,8 @@ def test_create_edit_and_delete_template(driver):
     choose_template_area_page = BasePage(driver)
     choose_template_area_page.click_element_by_link_text("Local authorities")
     choose_template_area_page.click_element_by_link_text("Adur")
-    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007564")
-    choose_template_area_page.select_checkbox_or_radio(value="wd23-E05007565")
+    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007564")
+    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007565")
     choose_template_area_page.click_continue()
     choose_template_area_page.click_element_by_link_text("Save and continue")
 

--- a/tests/functional/preview_and_dev/test_template_flow.py
+++ b/tests/functional/preview_and_dev/test_template_flow.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytest
 
-from config import config
+from config import COKEHAM_WARD_ID, EASTBROOK_WARD_ID, config
 from tests.pages import (
     CurrentAlertsPage,
     EditBroadcastTemplatePage,
@@ -73,8 +73,8 @@ def test_create_and_delete_template_with_area_only(driver):
     choose_template_area_page = BasePage(driver)
     choose_template_area_page.click_element_by_link_text("Local authorities")
     choose_template_area_page.click_element_by_link_text("Adur")
-    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007564")
-    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007565")
+    choose_template_area_page.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    choose_template_area_page.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     choose_template_area_page.click_continue()
     choose_template_area_page.click_element_by_link_text("Save and continue")
 
@@ -193,8 +193,8 @@ def test_create_edit_and_delete_template(driver):
     choose_template_area_page = BasePage(driver)
     choose_template_area_page.click_element_by_link_text("Local authorities")
     choose_template_area_page.click_element_by_link_text("Adur")
-    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007564")
-    choose_template_area_page.select_checkbox_or_radio(value="wd25-E05007565")
+    choose_template_area_page.select_checkbox_or_radio(value=COKEHAM_WARD_ID)
+    choose_template_area_page.select_checkbox_or_radio(value=EASTBROOK_WARD_ID)
     choose_template_area_page.click_continue()
     choose_template_area_page.click_element_by_link_text("Save and continue")
 


### PR DESCRIPTION
This PR updates the electoral ward IDs referenced in the tests, as they've changed with 2025 data.