### PR TITLE
EAS-2828 Fix cbc tests

### DIFF
--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -8,6 +8,7 @@ from clients.test_api_client import TestApiClient
 from config import config, setup_preview_dev_config
 from tests.test_utils import (
     clear_proxy_error_alarm,
+    create_ddb_client,
     put_functional_test_blackout_metric,
     set_response_codes,
 )
@@ -60,6 +61,12 @@ def cbc_blackout():
     clear_proxy_error_alarm()
     time.sleep(90)
     put_functional_test_blackout_metric(200)
+
+
+@pytest.fixture(scope="module")
+def dynamo_db_client():
+    ddbc = create_ddb_client()
+    yield ddbc
 
 
 def purge_functional_test_alerts(test_api_client):

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -291,7 +291,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
-    time.sleep(240)
+    time.sleep(120)
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -31,7 +31,6 @@ def test_cbc_config():
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_get_loopback_request_with_bad_id_returns_no_items(dynamo_db_client):
-    # ddbc = create_ddb_client()
     responses = get_loopback_request_items(ddbc=dynamo_db_client, request_id="1234")
     assert len(responses) == 0
 
@@ -40,8 +39,6 @@ def test_get_loopback_request_with_bad_id_returns_no_items(dynamo_db_client):
 def test_broadcast_generates_four_provider_messages(
     driver, api_client, dynamo_db_client
 ):
-    # ddbc = create_ddb_client()
-
     broadcast_id = str(uuid.uuid4())
     broadcast_alert(driver, broadcast_id)
 
@@ -73,7 +70,6 @@ def test_broadcast_generates_four_provider_messages(
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_get_loopback_responses_returns_codes_for_eight_endpoints(dynamo_db_client):
-    # ddbc = create_ddb_client()
     db_response = dynamo_db_client.scan(
         TableName="LoopbackResponses",
     )
@@ -103,8 +99,6 @@ def test_get_loopback_responses_returns_codes_for_eight_endpoints(dynamo_db_clie
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_set_loopback_response_codes(cbc_blackout, dynamo_db_client):
-    # ddbc = create_ddb_client()
-
     test_code = 403
     set_loopback_response_codes(dynamo_db_client, response_code=test_code)
     for mno in PROVIDERS:
@@ -146,28 +140,22 @@ def test_broadcast_with_az1_failure_tries_az2(
     broadcast_id = str(uuid.uuid4())
 
     mno = choice(PROVIDERS)
-    primary_cbc = f"{mno}-az1"
-    secondary_cbc = f"{mno}-az2"
+    az1 = f"{mno}-az1"
+    az2 = f"{mno}-az2"
     failure_code = 500
 
-    # ddbc = create_ddb_client()
     set_loopback_response_codes(
-        dynamo_db_client, response_code=failure_code, cbc_list=[primary_cbc]
+        dynamo_db_client, response_code=failure_code, cbc_list=[az1]
     )
 
     broadcast_alert(driver, broadcast_id)
-
     provider_messages = fetch_provider_messages(driver, api_client)
-
     assert len(provider_messages) == 4
 
     request_id = dict_item_for_key_value(provider_messages, "provider", mno, "id")
 
     def _check_for_responses_from_secondary_az(resp):
-        az2 = dynamo_item_for_key_value(
-            resp["Items"], "MnoName", secondary_cbc, "ResponseCode"
-        )
-        return az2 is None
+        return get_cbc_response_code(resp["Items"], az2) is None
 
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
@@ -178,7 +166,7 @@ def test_broadcast_with_az1_failure_tries_az2(
     set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
 
     az2_response_code = dynamo_item_for_key_value(
-        responses, "MnoName", secondary_cbc, "ResponseCode"
+        responses, "MnoName", az2, "ResponseCode"
     )
     assert az2_response_code == "200"
 
@@ -192,33 +180,26 @@ def test_broadcast_with_both_azs_failing_retries_requests(
     broadcast_id = str(uuid.uuid4())
 
     mno = choice(PROVIDERS)
-    primary_cbc = f"{mno}-az1"
-    secondary_cbc = f"{mno}-az2"
+    az1 = f"{mno}-az1"
+    az2 = f"{mno}-az2"
     failure_code = 500
-
-    # ddbc = create_ddb_client()
     set_loopback_response_codes(
         dynamo_db_client,
         response_code=failure_code,
-        cbc_list=[primary_cbc, secondary_cbc],
+        cbc_list=[az1, az2],
     )
 
     broadcast_alert(driver, broadcast_id)
-
     provider_messages = fetch_provider_messages(driver, api_client)
-
     assert len(provider_messages) == 4
 
     request_id = dict_item_for_key_value(provider_messages, "provider", mno, "id")
 
     def _check_for_responses_from_both_azs(resp):
-        az1 = dynamo_item_for_key_value(
-            resp["Items"], "MnoName", primary_cbc, "ResponseCode"
+        return (
+            get_cbc_response_code(resp["Items"], az1) is None
+            or get_cbc_response_code(resp["Items"], az2) is None
         )
-        az2 = dynamo_item_for_key_value(
-            resp["Items"], "MnoName", secondary_cbc, "ResponseCode"
-        )
-        return az1 is None or az2 is None
 
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
@@ -228,17 +209,11 @@ def test_broadcast_with_both_azs_failing_retries_requests(
 
     set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
 
-    az1_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", primary_cbc, "ResponseCode"
-    )
-    az1_codes_set = set(az1_response_codes)
+    az1_codes_set = set(get_cbc_response_codes(responses, az1))
     assert len(az1_codes_set) == 1  # assert that all codes are the same
     assert az1_codes_set.pop() == str(failure_code)
 
-    az2_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", secondary_cbc, "ResponseCode"
-    )
-    az2_codes_set = set(az2_response_codes)
+    az2_codes_set = set(get_cbc_response_codes(responses, az2))
     assert len(az2_codes_set) == 1  # assert that all codes are the same
     assert az2_codes_set.pop() == str(failure_code)
 
@@ -252,21 +227,18 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     broadcast_id = str(uuid.uuid4())
 
     mno = choice(PROVIDERS)
-    primary_cbc = f"{mno}-az1"
-    secondary_cbc = f"{mno}-az2"
+    az1 = f"{mno}-az1"
+    az2 = f"{mno}-az2"
     failure_code = 500
 
-    # ddbc = create_ddb_client()
     set_loopback_response_codes(
         dynamo_db_client,
         response_code=failure_code,
-        cbc_list=[primary_cbc, secondary_cbc],
+        cbc_list=[az1, az2],
     )
 
     broadcast_alert(driver, broadcast_id)
-
     provider_messages = fetch_provider_messages(driver, api_client)
-
     assert len(provider_messages) == 4
 
     request_id = dict_item_for_key_value(provider_messages, "provider", mno, "id")
@@ -278,16 +250,12 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
         retry_if=lambda resp: len(resp["Items"]) < 1,
     )
     set_loopback_response_codes(
-        ddbc=dynamo_db_client, response_code=200, cbc_list=[primary_cbc, secondary_cbc]
+        ddbc=dynamo_db_client, response_code=200, cbc_list=[az1, az2]
     )
     assert len(responses) >= 1
-    az1_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", primary_cbc, "ResponseCode"
+    response_codes = set(
+        get_cbc_response_codes(responses, az1) + get_cbc_response_codes(responses, az2)
     )
-    az2_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", secondary_cbc, "ResponseCode"
-    )
-    response_codes = set(az1_response_codes + az2_response_codes)
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
@@ -296,13 +264,9 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
         ddbc=dynamo_db_client,
         request_id=request_id,
     )
-    az1_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", primary_cbc, "ResponseCode"
+    response_codes = set(
+        get_cbc_response_codes(responses, az1) + get_cbc_response_codes(responses, az2)
     )
-    az2_response_codes = dynamo_items_for_key_value(
-        responses, "MnoName", secondary_cbc, "ResponseCode"
-    )
-    response_codes = set(az1_response_codes + az2_response_codes)
     assert len(response_codes) == 2  # we should have a 200 along with the 500s
     assert str(failure_code) in response_codes
     assert "200" in response_codes
@@ -394,12 +358,20 @@ def dynamo_item_for_key_value(data, key, value, item):
     return None
 
 
+def get_cbc_response_code(respones, cbc):
+    return dynamo_item_for_key_value(respones, "MnoName", cbc, "ResponseCode")
+
+
 def dynamo_items_for_key_value(data, key, value, item):
     items = list()
     for d in data:
         if list(d[key].values())[0] == value:
             items.append(list(d[item].values())[0])
     return items
+
+
+def get_cbc_response_codes(responses, cbc):
+    return dynamo_items_for_key_value(responses, "MnoName", cbc, "ResponseCode")
 
 
 def set_loopback_response_codes(ddbc, response_code=200, cbc_list=None):

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -291,7 +291,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
-    time.sleep(180)
+    time.sleep(240)
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,
@@ -404,7 +404,6 @@ def dynamo_items_for_key_value(data, key, value, item):
 
 def set_loopback_response_codes(ddbc, response_code=200, cbc_list=None):
     set_response_codes(ddbc=ddbc, response_code=response_code, cbc_list=cbc_list)
-    time.sleep(10)
 
 
 def fetch_provider_messages(driver, api_client):

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -12,12 +12,7 @@ from shapely import Polygon
 from config import config
 from tests.pages import RetryException
 from tests.pages.rollups import broadcast_alert, cancel_alert
-from tests.test_utils import (
-    PROVIDERS,
-    create_ddb_client,
-    create_s3_client,
-    set_response_codes,
-)
+from tests.test_utils import PROVIDERS, create_s3_client, set_response_codes
 
 test_group_name = "cbc-integration"
 
@@ -35,15 +30,17 @@ def test_cbc_config():
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_get_loopback_request_with_bad_id_returns_no_items():
-    ddbc = create_ddb_client()
-    responses = get_loopback_request_items(ddbc=ddbc, request_id="1234")
+def test_get_loopback_request_with_bad_id_returns_no_items(dynamo_db_client):
+    # ddbc = create_ddb_client()
+    responses = get_loopback_request_items(ddbc=dynamo_db_client, request_id="1234")
     assert len(responses) == 0
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_broadcast_generates_four_provider_messages(driver, api_client):
-    ddbc = create_ddb_client()
+def test_broadcast_generates_four_provider_messages(
+    driver, api_client, dynamo_db_client
+):
+    # ddbc = create_ddb_client()
 
     broadcast_id = str(uuid.uuid4())
     broadcast_alert(driver, broadcast_id)
@@ -60,7 +57,7 @@ def test_broadcast_generates_four_provider_messages(driver, api_client):
             provider_messages, "provider", provider_id, "id"
         )
         responses = get_loopback_request_items(
-            ddbc=ddbc,
+            ddbc=dynamo_db_client,
             request_id=request_id,
             retry_if=lambda resp: len(resp["Items"]) < 1,
         )
@@ -75,9 +72,9 @@ def test_broadcast_generates_four_provider_messages(driver, api_client):
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_get_loopback_responses_returns_codes_for_eight_endpoints():
-    ddbc = create_ddb_client()
-    db_response = ddbc.scan(
+def test_get_loopback_responses_returns_codes_for_eight_endpoints(dynamo_db_client):
+    # ddbc = create_ddb_client()
+    db_response = dynamo_db_client.scan(
         TableName="LoopbackResponses",
     )
 
@@ -105,16 +102,16 @@ def test_get_loopback_responses_returns_codes_for_eight_endpoints():
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_set_loopback_response_codes(cbc_blackout):
-    ddbc = create_ddb_client()
+def test_set_loopback_response_codes(cbc_blackout, dynamo_db_client):
+    # ddbc = create_ddb_client()
 
     test_code = 403
-    set_loopback_response_codes(ddbc, response_code=test_code)
+    set_loopback_response_codes(dynamo_db_client, response_code=test_code)
     for mno in PROVIDERS:
         for az in ["az1", "az2"]:
             test_cbc = f"{mno}-{az}"
             test_ip = config["cbcs"][test_cbc]
-            db_response = ddbc.query(
+            db_response = dynamo_db_client.query(
                 TableName="LoopbackResponses",
                 KeyConditionExpression="IpAddress = :IpAddress",
                 ExpressionAttributeValues={
@@ -125,12 +122,12 @@ def test_set_loopback_response_codes(cbc_blackout):
             assert db_response["Count"] == 1
             assert db_response["Items"][0]["ResponseCode"]["N"] == str(test_code)
 
-    set_loopback_response_codes(ddbc=ddbc, response_code=200)
+    set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
     for mno in PROVIDERS:
         for az in ["az1", "az2"]:
             test_cbc = f"{mno}-{az}"
             test_ip = config["cbcs"][test_cbc]
-            db_response = ddbc.query(
+            db_response = dynamo_db_client.query(
                 TableName="LoopbackResponses",
                 KeyConditionExpression="IpAddress = :IpAddress",
                 ExpressionAttributeValues={
@@ -143,7 +140,9 @@ def test_set_loopback_response_codes(cbc_blackout):
 
 
 @pytest.mark.xdist_group(name=test_group_name)
-def test_broadcast_with_az1_failure_tries_az2(driver, api_client, cbc_blackout):
+def test_broadcast_with_az1_failure_tries_az2(
+    driver, api_client, cbc_blackout, dynamo_db_client
+):
     broadcast_id = str(uuid.uuid4())
 
     mno = choice(PROVIDERS)
@@ -151,9 +150,9 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client, cbc_blackout):
     secondary_cbc = f"{mno}-az2"
     failure_code = 500
 
-    ddbc = create_ddb_client()
+    # ddbc = create_ddb_client()
     set_loopback_response_codes(
-        ddbc, response_code=failure_code, cbc_list=[primary_cbc]
+        dynamo_db_client, response_code=failure_code, cbc_list=[primary_cbc]
     )
 
     broadcast_alert(driver, broadcast_id)
@@ -171,12 +170,12 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client, cbc_blackout):
         return az2 is None
 
     responses = get_loopback_request_items(
-        ddbc=ddbc,
+        ddbc=dynamo_db_client,
         request_id=request_id,
         retry_if=_check_for_responses_from_secondary_az,
     )
 
-    set_loopback_response_codes(ddbc=ddbc, response_code=200)
+    set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
 
     az2_response_code = dynamo_item_for_key_value(
         responses, "MnoName", secondary_cbc, "ResponseCode"
@@ -188,7 +187,7 @@ def test_broadcast_with_az1_failure_tries_az2(driver, api_client, cbc_blackout):
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_with_both_azs_failing_retries_requests(
-    driver, api_client, cbc_blackout
+    driver, api_client, cbc_blackout, dynamo_db_client
 ):
     broadcast_id = str(uuid.uuid4())
 
@@ -197,9 +196,11 @@ def test_broadcast_with_both_azs_failing_retries_requests(
     secondary_cbc = f"{mno}-az2"
     failure_code = 500
 
-    ddbc = create_ddb_client()
+    # ddbc = create_ddb_client()
     set_loopback_response_codes(
-        ddbc, response_code=failure_code, cbc_list=[primary_cbc, secondary_cbc]
+        dynamo_db_client,
+        response_code=failure_code,
+        cbc_list=[primary_cbc, secondary_cbc],
     )
 
     broadcast_alert(driver, broadcast_id)
@@ -220,10 +221,12 @@ def test_broadcast_with_both_azs_failing_retries_requests(
         return az1 is None or az2 is None
 
     responses = get_loopback_request_items(
-        ddbc=ddbc, request_id=request_id, retry_if=_check_for_responses_from_both_azs
+        ddbc=dynamo_db_client,
+        request_id=request_id,
+        retry_if=_check_for_responses_from_both_azs,
     )
 
-    set_loopback_response_codes(ddbc=ddbc, response_code=200)
+    set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
 
     az1_response_codes = dynamo_items_for_key_value(
         responses, "MnoName", primary_cbc, "ResponseCode"
@@ -244,7 +247,7 @@ def test_broadcast_with_both_azs_failing_retries_requests(
 
 @pytest.mark.xdist_group(name=test_group_name)
 def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored(
-    driver, api_client, cbc_blackout
+    driver, api_client, cbc_blackout, dynamo_db_client
 ):
     broadcast_id = str(uuid.uuid4())
 
@@ -253,9 +256,11 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     secondary_cbc = f"{mno}-az2"
     failure_code = 500
 
-    ddbc = create_ddb_client()
+    # ddbc = create_ddb_client()
     set_loopback_response_codes(
-        ddbc, response_code=failure_code, cbc_list=[primary_cbc, secondary_cbc]
+        dynamo_db_client,
+        response_code=failure_code,
+        cbc_list=[primary_cbc, secondary_cbc],
     )
 
     broadcast_alert(driver, broadcast_id)
@@ -268,14 +273,16 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
 
     # wait for at least one response (which should be a '500' at this stage)
     _ = get_loopback_request_items(
-        ddbc=ddbc, request_id=request_id, retry_if=lambda resp: len(resp["Items"]) < 1
+        ddbc=dynamo_db_client,
+        request_id=request_id,
+        retry_if=lambda resp: len(resp["Items"]) < 1,
     )
 
-    set_loopback_response_codes(ddbc=ddbc, response_code=200)
+    set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
     time.sleep(120)
 
     responses = get_loopback_request_items(
-        ddbc=ddbc,
+        ddbc=dynamo_db_client,
         request_id=request_id,
     )
 

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -243,7 +243,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
 
     request_id = dict_item_for_key_value(provider_messages, "provider", mno, "id")
 
-    # wait for at least one response (which should be a '500' at this stage)
+    # wait for at least one response (which should be a '500' here)
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,
@@ -256,7 +256,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     response_codes = set(
         get_cbc_response_codes(responses, az1) + get_cbc_response_codes(responses, az2)
     )
-    assert len(response_codes) == 1  # we should one or more 500s here
+    assert len(response_codes) == 1  # 500 - only failures at this point
     assert str(failure_code) in response_codes
 
     time.sleep(120)
@@ -267,7 +267,9 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     response_codes = set(
         get_cbc_response_codes(responses, az1) + get_cbc_response_codes(responses, az2)
     )
-    assert len(response_codes) == 2  # we should have a 200 along with the 500s
+    assert (
+        len(response_codes) == 2
+    )  # 500 from at least one failed request, 200 from the successful broadcast
     assert str(failure_code) in response_codes
     assert "200" in response_codes
 

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -291,7 +291,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
-    time.sleep(120)
+    time.sleep(240)
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -272,28 +272,35 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     request_id = dict_item_for_key_value(provider_messages, "provider", mno, "id")
 
     # wait for at least one response (which should be a '500' at this stage)
-    _ = get_loopback_request_items(
+    responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,
         retry_if=lambda resp: len(resp["Items"]) < 1,
     )
+    assert len(responses) >= 1
+    az1_response_codes = dynamo_items_for_key_value(
+        responses, "MnoName", primary_cbc, "ResponseCode"
+    )
+    az2_response_codes = dynamo_items_for_key_value(
+        responses, "MnoName", secondary_cbc, "ResponseCode"
+    )
+    response_codes = set(az1_response_codes + az2_response_codes)
+    assert len(response_codes) == 1  # we should one or more 500s here
+    assert str(failure_code) in response_codes
 
     set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
-    time.sleep(120)
+    time.sleep(180)
 
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,
     )
-
     az1_response_codes = dynamo_items_for_key_value(
         responses, "MnoName", primary_cbc, "ResponseCode"
     )
-
     az2_response_codes = dynamo_items_for_key_value(
         responses, "MnoName", secondary_cbc, "ResponseCode"
     )
-
     response_codes = set(az1_response_codes + az2_response_codes)
     assert len(response_codes) == 2  # we should have a 200 along with the 500s
     assert str(failure_code) in response_codes

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -277,6 +277,9 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
         request_id=request_id,
         retry_if=lambda resp: len(resp["Items"]) < 1,
     )
+    set_loopback_response_codes(
+        ddbc=dynamo_db_client, response_code=200, cbc_list=[primary_cbc, secondary_cbc]
+    )
     assert len(responses) >= 1
     az1_response_codes = dynamo_items_for_key_value(
         responses, "MnoName", primary_cbc, "ResponseCode"
@@ -288,9 +291,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
-    set_loopback_response_codes(ddbc=dynamo_db_client, response_code=200)
     time.sleep(180)
-
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,

--- a/tests/functional/preview_and_dev/test_cbc_integration.py
+++ b/tests/functional/preview_and_dev/test_cbc_integration.py
@@ -259,7 +259,7 @@ def test_broadcast_with_both_azs_failing_eventually_succeeds_if_azs_are_restored
     assert len(response_codes) == 1  # we should one or more 500s here
     assert str(failure_code) in response_codes
 
-    time.sleep(240)
+    time.sleep(120)
     responses = get_loopback_request_items(
         ddbc=dynamo_db_client,
         request_id=request_id,


### PR DESCRIPTION
Use a single DynamoDB client across all CBC tests instead of creating a new one for every test function