### PR TITLE
EAS-3065: Try to actually wait for JS fully before invoking functions

### DIFF
--- a/tests/pages/pages.py
+++ b/tests/pages/pages.py
@@ -320,7 +320,7 @@ class PageWithStickyNavMixin:
             namespace = "window.GOVUK.stickAtTopWhenScrolling"
 
         # We need to wait for the JS to initialise and set the relevant global before using it
-        driver.page.wait_for_function(f"() => {namespace}")
+        driver.page.wait_for_function(f"() => Boolean(window.GOVUK && {namespace})")
 
         if selector is not None:
             js_str = (


### PR DESCRIPTION
#186, but this time I evaluate the parent object first. `wait_for_function` doesn't have much in the way of documentation, so it wasn't clear if erroring would result in it being retried vs throwing on the Python side.

It seems this doesn't work and resulted in a random test failure this morning. This code has been here two months though, so I suppose it doesn't happen too often!
<img width="1800" height="959" alt="image" src="https://github.com/user-attachments/assets/b3b4ed1e-c1ae-480a-b022-7a34a327565c" />
