### PR TITLE
EAS-3066: Disable top_rail tests in PRs

### DIFF
--- a/.github/workflows/run-functional-tests-pr.yml
+++ b/.github/workflows/run-functional-tests-pr.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Run functional tests
         env:
           CI: "true"
-          DISABLED_TEST_SUITES: cbc_integration # TODO: CBC approximation
+          DISABLED_TEST_SUITES: top_rail cbc_integration # TODO: CBC approximation
 
           GOVUK_ALERTS_URL: "local-govuk-alerts.s3-website.localhost.localstack.cloud:4566/alerts"
           BROADCAST_SERVICE_API_KEY: "functional_tests_localenv_key-8e1d56fa-12a8-4d00-bed2-db47180bed0a-86aa0bd2-f343-480f-85cd-d3010866cdee"


### PR DESCRIPTION
These don't account for different behaviour outside of business hours. Agreed in Slack just to skip them and have a ticket to change the app to act the same regardless of time of day.