### PR TITLE
EAS-3065: Tests: Call purge API keys endpoint

### DIFF
--- a/tests/functional/preview_and_dev/conftest.py
+++ b/tests/functional/preview_and_dev/conftest.py
@@ -36,6 +36,7 @@ def preview_dev_config():
     purge_folders_and_templates(test_api_client)
     purge_user_created_services(test_api_client)
     purge_users_created_by_functional_tests(test_api_client)
+    purge_api_keys_created_by_functional_tests(test_api_client)
     purge_password_history(
         test_api_client, config["broadcast_service"]["broadcast_user_3"]["id"]
     )
@@ -93,6 +94,13 @@ def purge_user_created_services(test_api_client):
 
 def purge_users_created_by_functional_tests(test_api_client):
     url = "/service/purge-users-created-by-tests"
+    test_api_client.delete(url)
+
+
+def purge_api_keys_created_by_functional_tests(test_api_client):
+    service = config["broadcast_service"]["service_id"]
+
+    url = f"/service/{service}/api-key/purge"
     test_api_client.delete(url)
 
 

--- a/tests/functional/preview_and_dev/test_platform_admin_flow.py
+++ b/tests/functional/preview_and_dev/test_platform_admin_flow.py
@@ -281,6 +281,7 @@ def test_service_can_create_and_approve_and_revoke_api_keys(
     assert api_keys_page.is_page_title("Create an API key")
 
     timestamp = str(int(time.time()))
+    # Only Key-* are purged
     key_name = "Key-" + timestamp
     api_keys_page.create_key(key_name=key_name)
     api_keys_page.wait_until_url_ends_with("/keys")


### PR DESCRIPTION
Requires https://github.com/alphagov/emergency-alerts-api/pull/362

`api:bugfix/eas-3065-purge-api-keys`