### PR TITLE
Log all containers (e.g. db-init) in container-logs artifacts

### DIFF
--- a/.github/workflows/run-functional-tests-pr.yml
+++ b/.github/workflows/run-functional-tests-pr.yml
@@ -131,7 +131,7 @@ jobs:
         if: always()
         run: |
           mkdir -p container-logs/
-          CONTAINER_NAMES=$(docker ps --format "{{.Names}}")
+          CONTAINER_NAMES=$(docker ps -a --format "{{.Names}}")
 
           for CONTAINER_NAME in $CONTAINER_NAMES
           do


### PR DESCRIPTION
If db-init were to fail it wouldn't be clear why, and we don't offer such data in the logs nor the downloadable artifacts. This fixes the latter.