### PR TITLE
EAS-3034: Change assert to wait for WebAuthn navigation

### DIFF
--- a/tests/functional/preview_and_dev/test_authentication_flow.py
+++ b/tests/functional/preview_and_dev/test_authentication_flow.py
@@ -146,5 +146,4 @@ def test_sign_in_with_webauthn_mfa(driver, purge_failed_logins):
     sign_in_page.wait_until_url_ends_with("/two-factor-webauthn")
     sign_in_page.click_element_by_link_text("Check security key")
 
-    landing_page = BasePage(driver)
-    assert landing_page.text_is_on_page("Switch service")
+    sign_in_page.wait_until_url_ends_with("current-alerts")


### PR DESCRIPTION
In the WebAuthn tests silly me used the dreaded `text_is_on_page` method, which has annoying side effects: it refreshes the page a few times to really check text _isn't_ there.

In preview this looks to have made the test a bit flaky, as I _think_ JavaScript on the page is trying to navigate (having just logged in) while the test logic here tries to reload the page. We then get an aborted error. Asserting/waiting for the URL to change seems much more reasonable.

<img width="866" height="239" alt="image" src="https://github.com/user-attachments/assets/57acbc19-b435-4f9e-8959-8ebb96cf5770" />
